### PR TITLE
feat: add MCP detection pack (Python + TypeScript)

### DIFF
--- a/claude_sdk/code_execution.yaml
+++ b/claude_sdk/code_execution.yaml
@@ -16,7 +16,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       has_code_exec_call: true

--- a/claude_sdk/error_handling.yaml
+++ b/claude_sdk/error_handling.yaml
@@ -15,7 +15,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       all:

--- a/claude_sdk/idempotency.yaml
+++ b/claude_sdk/idempotency.yaml
@@ -15,7 +15,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       all:

--- a/claude_sdk/network.yaml
+++ b/claude_sdk/network.yaml
@@ -15,7 +15,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       call_without_kwarg:

--- a/claude_sdk/path_safety.yaml
+++ b/claude_sdk/path_safety.yaml
@@ -15,7 +15,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     # call_uses_unnormalized_path_param is per-param: a tool with two path
     # params and one .resolve() correctly fires on the unresolved one.

--- a/claude_sdk/shell_safety.yaml
+++ b/claude_sdk/shell_safety.yaml
@@ -15,7 +15,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       has_shell_call: true

--- a/claude_sdk/ssrf.yaml
+++ b/claude_sdk/ssrf.yaml
@@ -15,7 +15,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       has_dynamic_url_call: true

--- a/claude_sdk/tool_definition.yaml
+++ b/claude_sdk/tool_definition.yaml
@@ -15,7 +15,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       has_docstring: false
@@ -35,7 +34,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       all:
@@ -57,7 +55,6 @@ rules:
     language: python
     applies_to:
       - claude_sdk_tool
-      - mcp_tool
     scope: tool
     match:
       name_in:

--- a/mcp/code_execution.yaml
+++ b/mcp/code_execution.yaml
@@ -1,0 +1,55 @@
+policy:
+  id: mcp_code_execution
+  name: MCP dynamic code execution
+  category: mcp
+  description: >
+    Rules covering MCP tool handlers that evaluate dynamic Python code.
+    eval/exec/compile inside a handler turns the server process into an
+    arbitrary-code-execution surface when any input flows from the client.
+
+rules:
+  - id: MCP-009
+    title: Tool body calls eval/exec/compile on dynamic input
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      The tool handler invokes Python's eval, exec, or compile. When any portion
+      of the input flows from the connecting client (directly, or via state the
+      model writes), the call is arbitrary code execution inside the MCP server
+      process: same memory, same imports, same in-process credentials. There is
+      no process boundary between the call and the server host. A model steered
+      by an untrusted document or a prompt-injected task can reach this primitive
+      and run whatever it constructs.
+    fix: >
+      Remove eval/exec/compile from the handler. For arithmetic use
+      ast.literal_eval; for richer expressions validate the AST against an
+      allow-list before compiling. If the tool is intentionally a code-execution
+      surface, run the code in a separate sandboxed single-use process (no
+      network, read-only filesystem, CPU/wall-clock caps), not in the server
+      process.
+
+  - id: MCP-014
+    title: TypeScript MCP tool evaluates dynamic code
+    severity: high
+    confidence: 0.9
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This MCP tool handler, authored in TypeScript, calls `eval()` or
+      constructs a `new Function(...)`. With model- or caller-controlled input
+      reaching the evaluated string, this is remote code execution inside the
+      MCP server process.
+    fix: >
+      Remove `eval`/`new Function`. Parse structured input with `JSON.parse`,
+      dispatch on a fixed map of allowed operations, and never construct
+      executable code from tool arguments.

--- a/mcp/error_handling.yaml
+++ b/mcp/error_handling.yaml
@@ -1,0 +1,31 @@
+policy:
+  id: mcp_error_handling
+  name: MCP error contract hygiene
+  category: mcp
+  description: >
+    Rules covering how an MCP tool handler surfaces failures back to the
+    connecting client. Raising raw exceptions yields opaque protocol errors
+    that a model cannot branch on intelligently.
+
+rules:
+  - id: MCP-006
+    title: Tool raises exceptions without a structured error contract
+    severity: medium
+    confidence: 0.6
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      When an MCP tool handler raises, the runtime surfaces the exception to the
+      connecting client as an opaque error. The model on the other end often
+      cannot recover or retry intelligently, and the raw message may leak
+      internal detail (stack frames, paths) across the server's trust boundary.
+    fix: >
+      Catch known failure modes and return a structured result the model can
+      branch on (e.g. {"error": ..., "retryable": bool}) instead of letting the
+      exception propagate as a protocol error.

--- a/mcp/idempotency.yaml
+++ b/mcp/idempotency.yaml
@@ -1,0 +1,46 @@
+policy:
+  id: mcp_idempotency
+  name: MCP mutating-tool idempotency
+  category: mcp
+  description: >
+    Rules that flag mutating MCP tools (create/send/refund/...) without an
+    idempotency key. Clients retry tool calls under timeouts and ambiguous
+    failures; without a key the same side effect can fire twice.
+
+rules:
+  - id: MCP-007
+    title: Mutating tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      The tool name signals a side effect (create/send/refund/…). MCP clients
+      retry tool calls under timeouts and ambiguous failures, and the same
+      model may be driven to repeat an action; without an idempotency key the
+      handler executes the mutation twice — a duplicate charge, order, or
+      message.
+    fix: >
+      Accept an idempotency key parameter (idempotency_key / request_id) and
+      de-duplicate server-side so a retried call is a no-op after the first
+      success.

--- a/mcp/network.yaml
+++ b/mcp/network.yaml
@@ -1,0 +1,50 @@
+policy:
+  id: mcp_network
+  name: MCP tool network hygiene
+  category: mcp
+  description: >
+    Rules covering outbound network calls made from inside MCP tool handlers.
+    The MCP runtime does not enforce timeouts on tool code; a hung request
+    inside a handler stalls the server's response to the connecting client.
+
+rules:
+  - id: MCP-004
+    title: Network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - requests.Session.get
+          - requests.Session.post
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - urllib.request.urlopen
+          - urlopen
+        missing: timeout
+    explanation: >
+      An MCP tool handler that makes a network request without a timeout can
+      hang indefinitely on a slow or unresponsive host. The MCP runtime does
+      not bound tool execution, so the stalled handler blocks the server's
+      reply to the connecting client and ties up the worker serving that
+      session. A kwarg present with literal None counts as missing.
+    fix: >
+      Pass timeout= (typically 5-30 seconds depending on the endpoint) to every
+      outbound call. Return the timeout to the client as a structured tool error
+      rather than letting the handler block.

--- a/mcp/path_safety.yaml
+++ b/mcp/path_safety.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: mcp_path_safety
+  name: MCP filesystem path safety
+  category: mcp
+  description: >
+    Rules that catch caller-supplied filesystem paths flowing into I/O calls
+    inside an MCP tool handler without containment. A traversal payload like
+    ../../etc/passwd reaches real filesystem state if the handler does not
+    resolve and gate the path.
+
+rules:
+  - id: MCP-005
+    title: Path parameter used in I/O without validation
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool accepts a path-like parameter and passes it to file or directory
+      operations without resolving or sandboxing the path. Because MCP tool
+      arguments are supplied by a connecting client (and chosen by a model from
+      conversation context), a `../../etc/passwd` is reachable and the server
+      reads or writes filesystem state outside any intended root. Detection is
+      heuristic — confirm the parameter is genuinely caller-supplied.
+    fix: >
+      Resolve the path with `Path(...).resolve()` and assert it sits under an
+      allowed root before any I/O touches it. Reject paths that escape the root.

--- a/mcp/shell_safety.yaml
+++ b/mcp/shell_safety.yaml
@@ -1,0 +1,56 @@
+policy:
+  id: mcp_shell_safety
+  name: MCP shell invocation safety
+  category: mcp
+  description: >
+    Rules covering MCP tool handlers that spawn OS processes. Process spawn
+    from inside a tool a connecting model can call exposes the server host's
+    shell with no runtime sandbox.
+
+rules:
+  - id: MCP-010
+    title: Tool body spawns a subprocess
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      The tool handler spawns an OS process (subprocess.*, os.system, os.popen,
+      or os.spawn*). Exposing process spawn to a connecting model is a wide
+      attack surface: command injection if any argument flows from a tool
+      argument into a shell string, arbitrary execution if the command itself is
+      caller-supplied, and unbounded resource use with no timeout. The MCP
+      runtime provides no sandbox; the subprocess inherits the server host's
+      filesystem, environment, and network credentials. Some tools legitimately
+      shell out, so this is a strong signal to review, not an automatic defect.
+    fix: >
+      Prefer a typed library API over shelling out. If a subprocess is required,
+      pass argv as a list (never shell=True), set timeout=, route through an
+      explicit command allow-list, and run the server under an OS sandbox with
+      no ambient credentials.
+
+  - id: MCP-012
+    title: TypeScript MCP tool spawns a subprocess
+    severity: high
+    confidence: 0.7
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This MCP tool handler, authored in TypeScript, invokes a child-process API
+      (child_process exec/execSync/spawn). Because a connecting model chooses the
+      arguments passed to the tool, a prompt-injected conversation can steer
+      those values into an OS command. Shelling out from a model-callable MCP
+      tool turns the server into an arbitrary-command primitive on its host.
+    fix: >
+      Avoid shelling out from MCP tools. If a subprocess is unavoidable, pass
+      arguments as an argv array (never a shell string), drop `shell: true`,
+      validate inputs against a strict allowlist, and run under a sandbox with no
+      ambient credentials.

--- a/mcp/ssrf.yaml
+++ b/mcp/ssrf.yaml
@@ -1,0 +1,60 @@
+policy:
+  id: mcp_ssrf
+  name: MCP server-side request forgery
+  category: mcp
+  description: >
+    Rules covering outbound HTTP requests from an MCP tool handler whose
+    destination URL is not a fixed literal. A tool that fetches a
+    caller-controlled URL can be steered at internal services the server host
+    can reach.
+
+rules:
+  - id: MCP-008
+    title: Tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.6
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This MCP tool issues an HTTP request to a URL built from a parameter or an
+      interpolated string rather than a fixed literal. Because MCP tool
+      arguments come from a connecting client (and a model choosing values from
+      conversation context), an attacker who can shape that context can drive
+      the request at an arbitrary host — including internal addresses the server
+      host can reach but the public internet cannot: cloud metadata endpoints
+      (169.254.169.254) that vend credentials, loopback admin APIs, and internal
+      services. This is server-side request forgery; the server becomes a proxy
+      for requests the attacker could not otherwise make.
+    fix: >
+      Constrain the destination to an explicit allow-list of hosts (or a single
+      fixed base URL with only a path parameter), reject requests to private,
+      loopback, and link-local IP ranges after DNS resolution, and disable
+      redirects to addresses outside the allow-list.
+
+  - id: MCP-013
+    title: TypeScript MCP tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This MCP tool handler, authored in TypeScript, issues an HTTP request to a
+      URL built from a tool argument or an interpolated string rather than a
+      fixed literal. Because a connecting model chooses tool arguments, a
+      prompt-injected conversation can drive the request at internal services the
+      server host can reach — cloud metadata endpoints (169.254.169.254),
+      loopback admin APIs, and other targets the public internet cannot. This is
+      server-side request forgery.
+    fix: >
+      Validate the destination before fetching: resolve the host and reject
+      private, loopback, and link-local ranges; prefer an allowlist of exact
+      hosts, or resolve an opaque ID against a server-side registry and build the
+      URL from the trusted entry.

--- a/mcp/tool_definition.yaml
+++ b/mcp/tool_definition.yaml
@@ -1,0 +1,104 @@
+policy:
+  id: mcp_tool_definition
+  name: MCP tool definition hygiene
+  category: mcp
+  description: >
+    Rules covering the structural hygiene of Model Context Protocol tool
+    registrations (@server.tool / @mcp.tool / .register_tool). An MCP server
+    advertises each tool's name, description, and input schema across a trust
+    boundary to whatever client and model connect to it, so weak definitions
+    degrade tool selection for every consumer of the server.
+
+rules:
+  - id: MCP-001
+    title: Tool has no description
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      An MCP server publishes each tool's description to connecting clients as
+      the text a model uses to decide whether to call the tool. A registration
+      with no docstring (and no explicit description) gives every connecting
+      model nothing to route on, leading to wrong-tool or skipped calls across
+      all clients of the server.
+    fix: >
+      Add a one-line docstring (or a description= argument on the registration)
+      stating what the tool does and when a model should call it. This text is
+      the tool's primary routing signal alongside its name.
+
+  - id: MCP-002
+    title: Tool has no type-annotated parameters
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_params: true
+      has_typed_params: false
+    explanation: >
+      MCP derives a tool's input JSON schema from the handler's Python type
+      annotations. Without annotations the advertised schema is degraded
+      (parameters fall back to an unconstrained type), so connecting models
+      send unvalidated inputs that frequently cause runtime errors inside the
+      server.
+    fix: >
+      Add type hints to every parameter (def search(query: str, limit: int = 10)
+      -> dict). Use Pydantic models or TypedDict for structured inputs so the
+      published schema constrains them.
+
+  - id: MCP-003
+    title: Ambiguous tool name
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - go
+        - thing
+        - stuff
+    explanation: >
+      Tool names like `process`, `handle`, or `run` give a connecting model no
+      signal about intent. Because an MCP server is consumed by clients the
+      author does not control, an ambiguous name degrades selection everywhere
+      the server is mounted, and collides more easily with similarly-named
+      tools from other servers in the same session.
+    fix: >
+      Rename to a verb-object form, e.g. `summarize_invoice`, `fetch_weather`.
+
+  - id: MCP-011
+    title: TypeScript MCP tool has no description
+    severity: low
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      An MCP server authored in TypeScript registers each tool with
+      `server.registerTool(name, {description, inputSchema}, handler)`. With no
+      `description` (or one built from a non-literal expression, captured as
+      empty), every connecting model loses the primary signal for deciding
+      whether to call the tool, causing wrong-tool or skipped calls across all
+      clients of the server.
+    fix: >
+      Provide a concise `description` string in the registration config stating
+      what the tool does and when a model should call it.


### PR DESCRIPTION
## Summary

Adds the `mcp/` detection pack (14 tool rules) and removes `mcp_tool` from the CSDK rules that carried it, so MCP-tool coverage lives in one place. Requires engine `trustabl/trustabl#3` (the `mcp` category + TypeScript MCP discovery) to load and fire.

## New `mcp/` pack
- **Python MCP-001..010** — tool_definition (no description, untyped params, ambiguous name), network timeout, path safety, error contract, idempotency, SSRF, code-exec, shell.
- **TypeScript MCP-011..014** — no description, shell, SSRF, eval / new Function.

All rules reuse existing predicates (no schema bump), with MCP-server-authoring framing.

## CSDK strip (clean separation)
`mcp_tool` removed from CSDK-001/002/003/004/005/006/007/009/107/108. Before this, MCP tools were only audited in repos where the `claude_sdk` pack happened to load, and an `mcp/` pack targeting `mcp_tool` would have double-fired in mixed repos. Now a pure-MCP repo is covered and a mixed Claude+MCP repo fires once, with MCP-specific framing.

## Verification
Mirrors `testdata/rules-fixture/mcp/` in the engine; `check-rules-sync.sh` exit 0; rulebook `trustabl/trustabl-rulebook` gate passes (102 rules, 0 warnings).
