### PR TITLE
docs: sync rule counts to 102/45 and document the mcp pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ against. Pick values from the table for the scope you're targeting.
 | `openai_agent`            | `Agent(...)` from `openai-agents` SDK                         |
 | `openai_sandbox_agent`    | `SandboxAgent(...)` from `openai-agents` SDK                  |
 | `claude_agent_definition` | `AgentDefinition(...)` from `claude-agent-sdk`                |
+| `claude_query_main`       | `query(...)` main-thread agent from the Claude TS SDK         |
 | `adk_llm_agent`           | `LlmAgent(...)` / `Agent(...)` alias from `google-adk`        |
 | `adk_sequential_agent`    | `SequentialAgent(...)` from `google-adk`                      |
 | `adk_parallel_agent`      | `ParallelAgent(...)` from `google-adk`                        |

--- a/README.md
+++ b/README.md
@@ -81,9 +81,18 @@ google_adk/                           Google ADK rules (ADK-NNN) — 26 rules
 ├── shell_safety.yaml                 ADK-010
 ├── ssrf.yaml                         ADK-012 (python), ADK-016 (typescript)
 └── tool_definition.yaml              ADK-001, ADK-002, ADK-007, ADK-009 (python), ADK-013 (typescript)
+mcp/                                  Model Context Protocol rules (MCP-NNN) — 14 rules
+├── code_execution.yaml               MCP-009, MCP-014
+├── error_handling.yaml               MCP-006
+├── idempotency.yaml                  MCP-007
+├── network.yaml                      MCP-004
+├── path_safety.yaml                  MCP-005
+├── shell_safety.yaml                 MCP-010, MCP-012
+├── ssrf.yaml                         MCP-008, MCP-013
+└── tool_definition.yaml              MCP-001, MCP-002, MCP-003, MCP-011
 ```
 
-Total: 88 rules across 37 yaml files. ID prefix denotes SDK; `NNN` tool scope,
+Total: 102 rules across 45 yaml files. ID prefix denotes SDK; `NNN` tool scope,
 `1NN` agent / subagent scope, `2NN` repo scope.
 
 The category is the first path segment. Group related rules into a topic file;


### PR DESCRIPTION
## What changed

Brings the rules-repo docs in line with the actual pack (verified by walking the YAML).

- **README.md** — the total read "88 rules across 37 yaml files"; corrected to **102 rules across 45 policy files**. Added the missing `mcp/` block (8 files, MCP-001..014) to the layout, which was omitted entirely.
- **CLAUDE.md** — added the `claude_query_main` agent token to the `applies_to` reference table. Two shipped rules (CSDK-130/131 — the Claude TS `query(...)` main-thread agent) depend on it, but it was undocumented.

## Why

A docs audit across the Trustabl repos found these counts had drifted after the MCP pack landed. This pack and the engine's fixture mirror are byte-identical at 102 rules / 45 files, `schema_version: 8`.

## Reviewer notes

- Docs-only — no rule YAML changed.
