### PR TITLE
feat(langchain): add the LangChain / LangGraph rule pack (LC-001..201)

### DIFF
--- a/langchain/agent_safety.yaml
+++ b/langchain/agent_safety.yaml
@@ -1,0 +1,80 @@
+policy:
+  id: langchain_agent_safety
+  name: LangChain agent safety
+  category: langchain
+  description: >
+    Agent-scope safety and reliability rules for LangChain / LangGraph agents
+    (create_react_agent, create_agent, AgentExecutor).
+
+rules:
+  - id: LC-101
+    title: LangChain agent wires a code-execution or shell built-in tool
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_agent
+      - langchain_agent_executor
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - PythonREPLTool
+        - PythonAstREPLTool
+        - ShellTool
+    explanation: >
+      This agent's tools list includes a LangChain built-in that executes code or
+      shell commands chosen by the model: PythonREPLTool / PythonAstREPLTool run
+      arbitrary Python, and ShellTool runs arbitrary shell commands. Once such a
+      tool is wired, a prompt injection or a confused model has a direct path to
+      arbitrary code execution in the agent process — these built-ins were the
+      vector in multiple published LangChain RCE advisories.
+    fix: >
+      Remove the REPL/shell built-in from production agents. If you genuinely need
+      code execution, run it in an isolated sandbox (no filesystem, no network, no
+      credentials, hard timeout) and gate it behind a human-in-the-loop approval
+      (a LangGraph interrupt_before breakpoint or a tool-approval middleware)
+      rather than letting the model invoke it unattended.
+
+  - id: LC-102
+    title: LangChain AgentExecutor has no max_iterations limit
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_agent_executor
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - max_iterations
+    explanation: >
+      This AgentExecutor sets no max_iterations, so a model that never emits a
+      final answer (it loops calling tools, or oscillates between two) runs until
+      it exhausts the API budget or wall-clock — there is no built-in ceiling. A
+      runaway tool-calling loop is a cost incident and, when the tools have side
+      effects, a correctness and safety one.
+    fix: >
+      Pass max_iterations= (and optionally max_execution_time=) to AgentExecutor,
+      sized to the task. Also set handle_parsing_errors= so a malformed model step
+      is surfaced rather than retried indefinitely.
+
+  - id: LC-111
+    title: TypeScript LangChain AgentExecutor has no maxIterations limit
+    severity: medium
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_agent_executor
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - maxIterations
+    explanation: >
+      This AgentExecutor sets no maxIterations, so a model that never returns a
+      final answer (it loops calling tools, or oscillates) runs until it exhausts
+      the API budget or wall-clock — there is no built-in ceiling. A runaway loop
+      is a cost incident and, when the tools have side effects, a correctness and
+      safety one.
+    fix: >
+      Pass maxIterations to the AgentExecutor options, sized to the task, and set
+      handleParsingErrors so a malformed step is surfaced rather than retried
+      indefinitely.

--- a/langchain/code_execution.yaml
+++ b/langchain/code_execution.yaml
@@ -1,0 +1,52 @@
+policy:
+  id: langchain_code_execution
+  name: LangChain dynamic-code-execution safety
+  category: langchain
+  description: >
+    Flags LangChain tools whose body evaluates code at runtime. Model-selected
+    code evaluation is a direct arbitrary-execution path.
+
+rules:
+  - id: LC-004
+    title: LangChain tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This LangChain tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. A model-callable tool that evaluates a
+      string can be steered by prompt injection to run attacker-chosen code in the
+      agent process. This is the same mechanism behind LangChain's own
+      PythonREPLTool; hand-rolling it in a tool body carries the identical risk.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser (ast.literal_eval
+      for data, a typed schema for arguments). If code execution is genuinely the
+      product, run it in a locked-down sandbox with no filesystem or network and a
+      hard timeout.
+
+  - id: LC-012
+    title: TypeScript LangChain tool evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This LangChain.js tool's handler calls eval() or constructs a new Function()
+      — both evaluate a string as code. A model-callable tool that evaluates its
+      input can be steered by prompt injection to execute attacker-chosen code in
+      the Node process.
+    fix: >
+      Remove eval / new Function from agent-callable tool handlers. Parse
+      structured input with JSON.parse or a typed schema instead. If code
+      execution is the product, run it in an isolated sandbox (a Worker with no
+      module access, or an external sandbox service) with a hard timeout.

--- a/langchain/repo_hygiene.yaml
+++ b/langchain/repo_hygiene.yaml
@@ -1,0 +1,40 @@
+policy:
+  id: langchain_repo_hygiene
+  name: LangChain repo hygiene
+  category: langchain
+  description: >
+    Repo-scoped hygiene rules for projects that use LangChain / LangGraph. Fire
+    once per scan against the repo manifest and inventory.
+
+rules:
+  - id: LC-201
+    title: LangChain project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - langchain
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - langchain
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses LangChain / LangGraph in code but ships no agent-guidance
+      doc (AGENTS.md or CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor
+      convention an editing coding agent reads before it acts; with neither file
+      present, any agent that opens this repo has no project-specific guidance on
+      which agent constructor to use (create_react_agent vs create_agent vs a raw
+      StateGraph), how tools must be defined and guarded, whether the REPL/shell
+      built-ins are permitted, or the local test and build commands. The likely
+      consequence is generated code that violates the project's tool and agent
+      contracts because nothing in-tree teaches the agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State which LangChain agent constructors the project uses and why, how tools
+      must be defined and guarded, any required human-in-the-loop gates, and the
+      exact test, lint, and build commands. Keep it short and concrete so an
+      editing agent can act on it without re-deriving the conventions.

--- a/langchain/shell_safety.yaml
+++ b/langchain/shell_safety.yaml
@@ -1,0 +1,54 @@
+policy:
+  id: langchain_shell_safety
+  name: LangChain shell-execution safety
+  category: langchain
+  description: >
+    Flags LangChain tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is a prompt-injection path to
+    arbitrary code execution.
+
+rules:
+  - id: LC-003
+    title: LangChain tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This LangChain tool's body invokes a shell primitive (subprocess.*,
+      os.system, os.popen, or os.spawn*). Because the tool is exposed to the
+      model, a prompt-injected or confused model can drive it to run arbitrary
+      commands with the agent process's privileges. Shell execution selected by
+      model output is the most direct path from prompt injection to remote code
+      execution.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox
+      with no ambient credentials. Keep shell logic out of any agent-callable tool.
+
+  - id: LC-011
+    title: TypeScript LangChain tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This LangChain.js tool's handler calls a child_process primitive (exec,
+      execSync, spawn, fork, …). Because the tool is exposed to the model, a
+      prompt-injected or confused model can drive it to run arbitrary shell
+      commands with the Node process's privileges — the most direct path from
+      prompt injection to remote code execution.
+    fix: >
+      Do not let model-controlled input reach a shell. Prefer a typed library
+      call; if a subprocess is unavoidable use execFile/spawn with an argument
+      array (never a shell string), allow-list the exact commands, and sandbox the
+      execution. Keep shell logic out of any agent-callable tool.

--- a/langchain/ssrf.yaml
+++ b/langchain/ssrf.yaml
@@ -1,0 +1,55 @@
+policy:
+  id: langchain_ssrf
+  name: LangChain SSRF safety
+  category: langchain
+  description: >
+    Flags LangChain tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery surface.
+
+rules:
+  - id: LC-005
+    title: LangChain tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This LangChain tool issues an HTTP request whose URL is built from a
+      parameter or interpolated value rather than a fixed literal. Because the
+      tool is model-callable, the model (or a prompt injection) controls the
+      destination — it can reach internal services, the cloud metadata endpoint
+      (169.254.169.254), or localhost admin ports the agent host can see but an
+      external caller cannot. This is a classic server-side request forgery
+      primitive handed to the model.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and
+      forbid raw model-supplied URLs. If the tool only ever talks to one service,
+      hard-code the base URL and accept only a path/query from the model.
+
+  - id: LC-013
+    title: TypeScript LangChain tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This LangChain.js tool calls fetch/axios/got with a URL built from a
+      non-literal value (a parameter, template string, or concatenation). Because
+      the tool is model-callable, the model or a prompt injection controls the
+      destination and can reach internal services, the cloud metadata endpoint, or
+      localhost admin ports visible to the Node host — a server-side request
+      forgery primitive.
+    fix: >
+      Validate the URL against an allow-list of hosts, reject private and
+      link-local ranges (and redirects into them), and never pass a raw
+      model-supplied URL to fetch. If the tool talks to one service, hard-code the
+      base URL and accept only a path from the model.

--- a/langchain/tool_behavior.yaml
+++ b/langchain/tool_behavior.yaml
@@ -1,0 +1,57 @@
+policy:
+  id: langchain_tool_behavior
+  name: LangChain tool behavior safety
+  category: langchain
+  description: >
+    Flags LangChain tool configuration that alters the agent's control flow in
+    ways that bypass the model's reasoning and any post-tool guardrails.
+
+rules:
+  - id: LC-006
+    title: LangChain tool returns its output directly, bypassing the model
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      tool_decorator_kwarg_value:
+        kwarg: return_direct
+        value: "True"
+    explanation: >
+      This tool sets return_direct=True, so LangChain returns the tool's raw
+      output straight to the caller and stops the agent loop — the model never
+      sees the result, cannot validate or summarize it, and any output guardrail
+      or post-processing step is skipped. Raw tool output (which may include
+      errors, secrets, or unsanitized external content) is handed to the user
+      verbatim, and multi-step plans that expect the model to act on the tool
+      result silently break.
+    fix: >
+      Leave return_direct at its default (False) unless you specifically intend to
+      short-circuit the agent. If you do, sanitize and shape the tool's output
+      yourself, since no model step or guardrail runs after it.
+
+  - id: LC-014
+    title: TypeScript LangChain tool returns its output directly, bypassing the model
+    severity: medium
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      tool_decorator_kwarg_value:
+        kwarg: returnDirect
+        value: "true"
+    explanation: >
+      This tool sets returnDirect: true, so LangChain.js returns the tool's raw
+      output straight to the caller and halts the agent loop — the model never
+      sees the result and any post-tool guardrail or formatting step is skipped.
+      Unsanitized tool output (errors, secrets, external content) reaches the user
+      verbatim, and multi-step plans that depend on the model reacting to the
+      result break.
+    fix: >
+      Leave returnDirect at its default (false) unless you deliberately intend to
+      short-circuit the agent. If you do, sanitize and shape the output in the
+      handler, because no model step or guardrail runs after it.

--- a/langchain/tool_definition.yaml
+++ b/langchain/tool_definition.yaml
@@ -1,0 +1,79 @@
+policy:
+  id: langchain_tool_definition
+  name: LangChain tool definition hygiene
+  category: langchain
+  description: >
+    Hygiene rules for LangChain / LangGraph tools — the @tool decorator and
+    StructuredTool / Tool factories (Python), and the tool() factory /
+    DynamicStructuredTool / DynamicTool (TypeScript). These surfaces drive
+    whether the model can reason about a tool and call it correctly.
+
+rules:
+  - id: LC-001
+    title: LangChain tool has no description
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      LangChain exposes a tool to the model through its description: for an
+      @tool-decorated function or a StructuredTool, the description defaults to
+      the wrapped function's docstring. A tool with no docstring (and no explicit
+      description=) reaches the model as a bare name, so the model cannot tell
+      what the tool does or when to call it — it will skip the tool or invoke it
+      with the wrong arguments. This is the single highest-leverage authoring fix.
+    fix: >
+      Add a one-paragraph docstring to the wrapped function describing what the
+      tool does, the inputs it expects, and what it returns — or pass an explicit
+      description= to StructuredTool/Tool. The model reads this string verbatim.
+
+  - id: LC-002
+    title: LangChain tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      LangChain builds a tool's argument schema from the wrapped function's type
+      hints (or an explicit args_schema Pydantic model). A tool whose parameters
+      carry no annotations produces an underspecified schema: the model gets no
+      type guidance and passes arguments of the wrong shape, which LangChain then
+      rejects at validation time — a silent reliability tax on every call.
+    fix: >
+      Annotate every parameter with a concrete type (str, int, list[str], a
+      Pydantic model, etc.), or pass an args_schema= to StructuredTool. LangChain
+      propagates these into the JSON schema the model sees.
+
+  - id: LC-010
+    title: TypeScript LangChain tool has no description
+    severity: low
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      LangChain.js exposes a tool to the model through the description field in
+      its config object (the second argument to tool(), or the options for
+      DynamicStructuredTool / DynamicTool). The model reads that string verbatim
+      to decide whether and how to call the tool. A tool built with no description
+      gives the model no signal about its purpose, so it under-calls the tool or
+      calls it with the wrong arguments. Unlike Python, where the docstring is a
+      fallback, the JS SDK takes the description as an explicit field — omitting it
+      is a silent gap.
+    fix: >
+      Pass a one-sentence description in the tool() config (or the
+      DynamicStructuredTool options) naming what the tool does, the inputs it
+      expects, and what it returns. Write it for the model, not a human reader.


### PR DESCRIPTION
## Summary

The production **LangChain / LangGraph** rule pack — 15 rules (`LC-001..201`) across 7 topic files. Byte-for-byte mirror of `testdata/rules-fixture/langchain` in the engine.

Coordinated **3-repo change** (merge together):
- **trustabl/trustabl** — engine discovery + loader wiring + fixture rules + tests — trustabl/trustabl#18
- **trustabl-rules** (this PR) — the production rule pack
- **trustabl-rulebook** — rationale docs for all 15 rules

## Rules

| Topic | Rules |
|---|---|
| `tool_definition` | LC-001 no description, LC-002 untyped params, LC-010 (TS) no description |
| `shell_safety` | LC-003 (Py), LC-011 (TS) — tool body spawns a subprocess |
| `code_execution` | LC-004 (Py), LC-012 (TS) — tool evaluates dynamic code |
| `ssrf` | LC-005 (Py), LC-013 (TS) — tool fetches a caller-controlled URL |
| `tool_behavior` | LC-006 (Py), LC-014 (TS) — `return_direct` bypasses the model |
| `agent_safety` | LC-101 code-exec/shell built-in, LC-102 (Py) / LC-111 (TS) AgentExecutor has no iteration limit |
| `repo_hygiene` | LC-201 no agent-guidance doc (AGENTS.md/CLAUDE.md) |

## Schema

Uses only existing predicates — **no `schema_version` bump** (stays at 8). The engine PR (trustabl/trustabl#18) adds the `langchain` category and the `applies_to` tokens the loader needs to accept these rules, so this pack requires that engine build.
