### PR TITLE
feat: add CrewAI, AutoGen/AG2, Vercel AI SDK, and Pydantic AI rule packs

### DIFF
--- a/autogen/agent_safety.yaml
+++ b/autogen/agent_safety.yaml
@@ -1,0 +1,145 @@
+policy:
+  id: autogen_agent_safety
+  name: AutoGen agent safety
+  category: autogen
+  description: >
+    Agent-scope safety rules for AutoGen / AG2 agents. These flag constructor
+    kwargs that hand a model-driven agent host code execution with no container,
+    no human review, or no loop bound — the configurations AutoGen's own docs
+    warn against ("we strongly recommend Docker"; "local execution is not
+    recommended").
+
+rules:
+  - id: AG2-001
+    title: AutoGen executor runs code on the host without Docker
+    severity: high
+    confidence: 0.9
+    language: python
+    applies_to:
+      - autogen_conversable_agent
+      - autogen_user_proxy_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: code_execution_config.use_docker
+        value: "False"
+    explanation: >
+      This agent sets code_execution_config={"use_docker": False}, so every code
+      block the model emits is written to disk and executed directly on the host
+      with the agent process's privileges — no container, no isolation. Because the
+      conversation, tool outputs, and any retrieved content are all model-reachable,
+      a single prompt injection turns into host remote code execution. AutoGen's own
+      documentation strongly recommends Docker for exactly this reason: container
+      execution is the boundary that keeps model-chosen code off the host.
+    fix: >
+      Set use_docker=True (the default when Docker is available) so generated code
+      runs inside a container, or disable code execution on this agent entirely
+      (code_execution_config=False) and move any genuine code-running need to a
+      hardened external sandbox gated behind explicit human approval.
+
+  - id: AG2-002
+    title: AutoGen executor runs code with no human review (human_input_mode=NEVER)
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_conversable_agent
+      - autogen_user_proxy_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_value:
+            kwarg: human_input_mode
+            value: NEVER
+        - agent_kwarg_present:
+            - code_execution_config
+    explanation: >
+      This agent enables code execution (code_execution_config is set) while
+      human_input_mode="NEVER" removes the human-in-the-loop step. The combination
+      makes the agent fully autonomous: every code block the model emits runs with
+      zero review, so a prompt injection or a confused model executes attacker-chosen
+      code with no chance for a human to intervene. AutoGen's human_input_mode exists
+      precisely to gate this; setting it to NEVER on a code-executing agent removes
+      the last checkpoint before execution.
+    fix: >
+      Set human_input_mode="ALWAYS" (or "TERMINATE") on any agent that executes
+      code, so a human approves each run, or disable code execution on this agent
+      (code_execution_config=False). If unattended execution is a hard requirement,
+      run the code in a hardened external sandbox with no host access rather than via
+      the AutoGen executor.
+
+  - id: AG2-004
+    title: AutoGen GroupChatManager has no max_round bound
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_group_chat_manager
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - max_round
+    explanation: >
+      This group chat does not set max_round, so the speaker-selection loop has no
+      upper bound on the number of turns. A degenerate conversation — two agents that
+      keep handing work back and forth, or a model that never emits the termination
+      signal — runs until something else stops it, burning token budget the whole
+      time. When the participating agents wield side-effecting tools (file writes,
+      shell, network), an unbounded loop is not just a cost incident but a
+      correctness one: the same mutation can be applied many times over.
+    fix: >
+      Pass max_round= to GroupChat / GroupChatManager with a concrete cap sized to
+      the workflow (often 10–25). Pair it with a clear termination condition so the
+      chat ends on success rather than only on the round cap.
+
+  - id: AG2-005
+    title: AutoGen AssistantAgent enables code execution on the LLM agent
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - autogen_assistant_agent
+    scope: agent
+    match:
+      agent_kwarg_present:
+        - code_execution_config
+    explanation: >
+      This AssistantAgent sets code_execution_config, enabling code execution on the
+      LLM-facing agent. AutoGen's recommended pattern splits responsibilities: the
+      AssistantAgent generates code with code_execution_config=False, and a separate
+      UserProxyAgent (the executor) runs it. Collapsing both roles into one agent
+      removes that review boundary — the same agent that the model fully controls
+      also executes whatever it produces, so a prompt injection has a direct path
+      from generation to execution.
+    fix: >
+      Set code_execution_config=False on the AssistantAgent and route execution
+      through a dedicated UserProxyAgent executor, keeping the generate/execute split
+      AutoGen recommends. Apply the executor's own safety controls (Docker,
+      human_input_mode) on that proxy rather than on the assistant.
+
+  - id: AG2-006
+    title: AutoGen executor with code execution has no auto-reply cap
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - autogen_conversable_agent
+      - autogen_user_proxy_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_present:
+            - code_execution_config
+        - agent_kwarg_missing:
+            - max_consecutive_auto_reply
+    explanation: >
+      This executor enables code execution (code_execution_config is set) but does
+      not set max_consecutive_auto_reply, so there is no cap on how many times it will
+      auto-respond — and therefore auto-execute model-emitted code — in a single
+      exchange. An agent that keeps replying without limit can run generated code an
+      unbounded number of times, amplifying both the cost and the blast radius of a
+      single injected instruction.
+    fix: >
+      Set max_consecutive_auto_reply= to a small integer on any code-executing agent
+      so the auto-reply loop is bounded, and combine it with human_input_mode and
+      Docker so each run is both capped and reviewed.

--- a/autogen/code_execution.yaml
+++ b/autogen/code_execution.yaml
@@ -1,0 +1,33 @@
+policy:
+  id: autogen_code_execution
+  name: AutoGen code-execution safety
+  category: autogen
+  description: >
+    Flags AutoGen tools whose body evaluates code at runtime. Model-selected code
+    execution is a direct arbitrary-execution path; AutoGen's own docs recommend
+    Docker and warn that local execution is not recommended.
+
+rules:
+  - id: AG2-010
+    title: AutoGen tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This AutoGen tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. Because the tool is registered with an agent
+      and exposed to the model, a prompt injection can steer it to run attacker-chosen
+      Python in the agent process. This is the same arbitrary-execution risk AutoGen's
+      code executor carries — and AutoGen's documentation strongly recommends running
+      such code inside Docker, not directly via in-process eval/exec.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser (ast.literal_eval
+      for data, a typed schema for arguments). If running code is genuinely the
+      product, route it through AutoGen's Docker code executor or a locked-down
+      external sandbox with no filesystem or network and a hard timeout.

--- a/autogen/network.yaml
+++ b/autogen/network.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: autogen_network
+  name: AutoGen tool network hygiene
+  category: autogen
+  description: >
+    Network-call hygiene inside AutoGen-registered tool functions. A tool that
+    makes a network request without a timeout can hang the conversation loop
+    indefinitely.
+
+rules:
+  - id: AG2-012
+    title: AutoGen tool network call has no timeout
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+        missing: timeout
+    explanation: >
+      This AutoGen tool makes a network request without a timeout, so it will hang
+      indefinitely on a slow or unresponsive remote. AutoGen has no tool-level
+      timeout — the entire agent conversation blocks until the request returns, and
+      under load this exhausts whatever runtime the agent is hosted on without ever
+      surfacing the failure to the model.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough to allow legitimate slow responses for
+      this endpoint, and surface failures as a structured error the model can react
+      to.

--- a/autogen/repo_hygiene.yaml
+++ b/autogen/repo_hygiene.yaml
@@ -1,0 +1,40 @@
+policy:
+  id: autogen_repo_hygiene
+  name: AutoGen repo hygiene
+  category: autogen
+  description: >
+    Repo-scoped hygiene rules for projects that use AutoGen / AG2. Fire once per
+    scan against the repo manifest and inventory.
+
+rules:
+  - id: AG2-201
+    title: AutoGen project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - autogen
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - autogen
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses AutoGen in code but ships no agent-guidance doc (AGENTS.md or
+      CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor convention an editing
+      coding agent reads before it acts; with neither file present, any agent that
+      opens this repo has no project-specific guidance on how agents and tools must be
+      configured — in particular, whether code execution is permitted, whether the
+      executor must run in Docker, and whether human_input_mode may be set to NEVER.
+      The likely consequence is generated code that violates the project's safety
+      contract because nothing in-tree teaches the agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule). State
+      whether code execution is permitted and under what guard (Docker,
+      human_input_mode), how tools must be registered and constrained, any required
+      human-in-the-loop gates, and the exact test, lint, and build commands. Keep it
+      short and concrete so an editing agent can act on it without re-deriving the
+      conventions.

--- a/autogen/shell_safety.yaml
+++ b/autogen/shell_safety.yaml
@@ -1,0 +1,32 @@
+policy:
+  id: autogen_shell_safety
+  name: AutoGen shell-execution safety
+  category: autogen
+  description: >
+    Flags AutoGen tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution.
+
+rules:
+  - id: AG2-009
+    title: AutoGen tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This AutoGen tool's body invokes a shell primitive (subprocess.*, os.system,
+      os.popen, or os.spawn*). Because the tool is registered with an agent and
+      exposed to the model, a prompt-injected or confused model can drive it to run
+      arbitrary commands with the agent process's privileges — shell execution
+      selected by model output is the most direct path from prompt injection to
+      remote code execution.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox with
+      no ambient credentials. Keep shell logic out of any agent-callable tool.

--- a/autogen/ssrf.yaml
+++ b/autogen/ssrf.yaml
@@ -1,0 +1,32 @@
+policy:
+  id: autogen_ssrf
+  name: AutoGen SSRF safety
+  category: autogen
+  description: >
+    Flags AutoGen tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery
+    surface a model-callable tool exposes.
+
+rules:
+  - id: AG2-011
+    title: AutoGen tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This AutoGen tool issues an HTTP request whose URL is built from a parameter
+      or interpolated value rather than a fixed literal. Because the tool is
+      model-callable, the model (or a prompt injection) controls the destination —
+      it can reach internal services, the cloud metadata endpoint (169.254.169.254),
+      or localhost admin ports the agent host can see but an external caller cannot.
+      This is a classic server-side request forgery primitive handed to the model.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and forbid
+      raw model-supplied URLs. If the tool only ever talks to one service, hard-code
+      the base URL and accept only a path or query from the model.

--- a/autogen/tool_definition.yaml
+++ b/autogen/tool_definition.yaml
@@ -1,0 +1,56 @@
+policy:
+  id: autogen_tool_definition
+  name: AutoGen tool definition hygiene
+  category: autogen
+  description: >
+    Hygiene rules for AutoGen tools registered via register_function or the
+    register_for_llm / register_for_execution decorators. AutoGen turns the
+    registered function's docstring and parameter type hints into the tool's
+    description and argument schema for the model.
+
+rules:
+  - id: AG2-007
+    title: AutoGen tool has no description
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      AutoGen advertises a registered function to the model through its description,
+      which it derives from the function's docstring (unless an explicit description=
+      is passed at registration). A tool with neither reaches the model as a bare
+      name, so the model cannot tell what the tool does or when to call it — it will
+      skip the tool or invoke it with the wrong arguments. This is the single
+      highest-leverage authoring fix.
+    fix: >
+      Add a one-paragraph docstring to the registered function describing what the
+      tool does, the inputs it expects, and what it returns — or pass description= at
+      registration. AutoGen passes this text to the model verbatim, so write it for
+      the model rather than a human maintainer.
+
+  - id: AG2-008
+    title: AutoGen tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      AutoGen builds a tool's argument schema from the registered function's type
+      hints. A tool whose parameters carry no annotations produces an underspecified
+      schema: the model gets no type guidance and passes arguments of the wrong
+      shape, which the SDK then rejects at validation time — a silent reliability tax
+      on every call.
+    fix: >
+      Annotate every parameter with a concrete type (str, int, list[str], a
+      typing.Annotated description, etc.). AutoGen propagates these annotations into
+      the schema the model sees, so the model emits correctly-shaped arguments.

--- a/crewai/agent_safety.yaml
+++ b/crewai/agent_safety.yaml
@@ -1,0 +1,89 @@
+policy:
+  id: crewai_agent_safety
+  name: CrewAI agent safety
+  category: crewai
+  description: >
+    Agent-scope safety rules for CrewAI agents (the Agent(...) constructor).
+    These flag constructor kwargs that hand the model code-execution or
+    delegation capabilities — the entry points of CrewAI's published RCE and
+    confused-deputy chains.
+
+rules:
+  - id: CREW-101
+    title: CrewAI agent enables built-in code execution
+    severity: high
+    confidence: 0.9
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: allow_code_execution
+        value: "True"
+    explanation: >
+      This Agent sets allow_code_execution=True, which makes CrewAI auto-inject a
+      CodeInterpreterTool into the agent's tool set. From that point the model can
+      run arbitrary Python it generates — and because the agent's instructions and
+      tool outputs are model-reachable, a prompt injection has a direct path to
+      code execution. This flag is the entry point of CrewAI's published RCE chain:
+      CVE-2026-2275 escapes the SandboxPython interpreter via a ctypes call, and
+      CVE-2026-2287 silently falls back from the Docker sandbox to host execution
+      when Docker is unavailable. The flag is also deprecated upstream.
+    fix: >
+      Remove allow_code_execution=True. If the agent genuinely needs to run code,
+      do it outside CrewAI in a hardened external sandbox (E2B, Modal, or an
+      equivalent isolated runner with no filesystem, no network, no credentials,
+      and a hard timeout) and gate it behind an explicit human approval rather than
+      letting the model invoke an in-process interpreter.
+
+  - id: CREW-102
+    title: CrewAI agent runs code execution in unsafe mode
+    severity: high
+    confidence: 0.9
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: code_execution_mode
+        value: unsafe
+    explanation: >
+      This Agent sets code_execution_mode="unsafe", which tells CrewAI to run
+      model-generated code directly on the host instead of inside the Docker
+      sandbox. There is no boundary left to escape: a single prompt injection or a
+      confused model yields arbitrary code execution with the agent process's
+      privileges. This is strictly worse than the default "safe" mode, which at
+      least confines execution to a container.
+    fix: >
+      Remove code_execution_mode="unsafe" (the default "safe" mode keeps execution
+      in Docker). Better still, do not run model-chosen code in-process at all —
+      move it to a hardened external sandbox and require a human approval before
+      any code runs.
+
+  - id: CREW-104
+    title: CrewAI agent allows delegation to peer agents
+    severity: medium
+    confidence: 0.75
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: allow_delegation
+        value: "True"
+    explanation: >
+      This Agent sets allow_delegation=True, so it can hand work to any peer agent
+      in the crew and invoke their tools. Delegation widens the agent's effective
+      trust boundary to the union of every peer's capabilities with no
+      per-delegation gate — a classic confused-deputy setup. If any peer holds the
+      code interpreter or an unconstrained file reader, a prompt injection against
+      this agent can reach that capability indirectly, even though this agent was
+      never granted it directly.
+    fix: >
+      Set allow_delegation=False unless delegation is essential to the workflow.
+      If the crew must delegate, keep high-risk tools (code execution, file read,
+      shell) off every agent reachable through delegation, and constrain each
+      peer's tool set to the minimum its role requires.

--- a/crewai/code_execution.yaml
+++ b/crewai/code_execution.yaml
@@ -1,0 +1,62 @@
+policy:
+  id: crewai_code_execution
+  name: CrewAI code-execution safety
+  category: crewai
+  description: >
+    Flags CrewAI agents wired with the code-interpreter built-in and CrewAI
+    tools whose body evaluates code at runtime. Model-selected code execution is
+    a direct arbitrary-execution path and the root of CrewAI's published RCE
+    advisories.
+
+rules:
+  - id: CREW-103
+    title: CrewAI agent wires the code-interpreter built-in tool
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - CodeInterpreterTool
+    explanation: >
+      This agent's tools list includes CodeInterpreterTool, CrewAI's built-in that
+      executes Python the model generates. It is the same arbitrary-execution
+      capability that allow_code_execution=True auto-injects (CREW-101), reached
+      here by wiring the tool by hand. Once it is in the tool set, a prompt
+      injection or a confused model can run attacker-chosen code in the agent
+      process — the vector behind CVE-2026-2275 (SandboxPython ctypes escape) and
+      CVE-2026-2287 (Docker-availability fallback to host execution). The CERT
+      remediation for those advisories is literally to remove or disable the Code
+      Interpreter Tool.
+    fix: >
+      Remove CodeInterpreterTool from production agents. If code execution is a
+      genuine requirement, run it outside CrewAI in a hardened external sandbox
+      (no filesystem, no network, no credentials, hard timeout) and gate it behind
+      an explicit human approval rather than exposing an in-process interpreter to
+      the model.
+
+  - id: CREW-003
+    title: CrewAI tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This CrewAI tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. Because the tool is exposed to the model, a
+      prompt injection can steer it to run attacker-chosen Python in the agent
+      process. This is the same mechanism behind CrewAI's CodeInterpreterTool;
+      hand-rolling it inside a @tool body carries the identical risk while bypassing
+      whatever sandboxing the built-in would have applied.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser (ast.literal_eval
+      for data, a typed schema for arguments). If running code is genuinely the
+      product, isolate it in a locked-down sandbox with no filesystem or network
+      and a hard timeout.

--- a/crewai/dangerous_tools.yaml
+++ b/crewai/dangerous_tools.yaml
@@ -1,0 +1,73 @@
+policy:
+  id: crewai_dangerous_tools
+  name: CrewAI dangerous built-in tools
+  category: crewai
+  description: >
+    Flags CrewAI agents wired with high-risk crewai_tools built-ins: an
+    unconstrained file reader, and the web-fetching / RAG tools that retrieve
+    model-chosen URLs. Both are vectors in CrewAI's published file-read and SSRF
+    advisories.
+
+rules:
+  - id: CREW-106
+    title: CrewAI agent grants an unconstrained FileReadTool
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      all:
+        - agent_uses_hosted_tool_class: [FileReadTool]
+        - not:
+            agent_hosted_tool_kwarg_present:
+              class: FileReadTool
+              kwarg: file_path
+    explanation: >
+      This agent wires FileReadTool with no file_path= pin, so the tool reads
+      whatever path the model names at call time. Because the tool is
+      model-callable, a prompt injection can make it read any file the agent
+      process can see — /etc/passwd, ~/.ssh/id_rsa, application secrets — which is
+      the arbitrary-file-read exposure tracked as CVE-2026-2285 (path traversal in
+      the file-read tool). Pinning the tool to a specific file at construction
+      removes the model's control over the target, so FileReadTool(file_path="...")
+      is the safe form and does not fire.
+    fix: >
+      Construct FileReadTool(file_path="...") bound to the one file the agent
+      needs, so the model cannot choose the path. If the agent must read several
+      files, validate every candidate path against an allow-list of directories,
+      resolve symlinks, and reject any path that escapes the intended root.
+
+  - id: CREW-107
+    title: CrewAI agent wires a tool that fetches model-chosen URLs
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - ScrapeWebsiteTool
+        - SeleniumScrapingTool
+        - WebsiteSearchTool
+        - SerperDevTool
+        - JSONSearchTool
+        - PDFSearchTool
+        - CSVSearchTool
+    explanation: >
+      This agent wires a crewai_tools built-in that issues outbound requests to a
+      URL the model supplies (a scraper, a search tool, or a RAG retriever). Because
+      the destination is model-controlled, a prompt injection can point it at
+      internal services or the cloud metadata endpoint (169.254.169.254) to exfil
+      credentials — the server-side request forgery exposure tracked as
+      CVE-2026-2286. The retrieved page content then re-enters the conversation as
+      untrusted text, giving the fetched site a second-order prompt-injection
+      channel into the agent.
+    fix: >
+      Constrain the destination: validate every URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and forbid
+      raw model-supplied URLs. Treat any retrieved content as untrusted input —
+      keep it out of the system prompt and do not let it silently expand the agent's
+      tool permissions.

--- a/crewai/idempotency.yaml
+++ b/crewai/idempotency.yaml
@@ -1,0 +1,45 @@
+policy:
+  id: crewai_idempotency
+  name: CrewAI mutating-tool idempotency
+  category: crewai
+  description: >
+    Rules that flag mutating tools (create/send/refund/...) without an
+    idempotency key. CrewAI retries tool calls under timeouts and ambiguous
+    failures; without a key the same side-effecting action can fire twice.
+
+rules:
+  - id: CREW-006
+    title: Mutating CrewAI tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). CrewAI retries tool
+      calls under timeouts and ambiguous failures; without an idempotency key the
+      same action can fire twice — a duplicate charge, a double-sent message, a
+      repeated delete. Downstream services must also honor the key for this
+      protection to be effective.
+    fix: >
+      Add an `idempotency_key: str` parameter and pass it through to the backing
+      API so a retried call is recognized and deduplicated rather than re-executed.

--- a/crewai/repo_hygiene.yaml
+++ b/crewai/repo_hygiene.yaml
@@ -1,0 +1,40 @@
+policy:
+  id: crewai_repo_hygiene
+  name: CrewAI repo hygiene
+  category: crewai
+  description: >
+    Repo-scoped hygiene rules for projects that use CrewAI. Fire once per scan
+    against the repo manifest and inventory.
+
+rules:
+  - id: CREW-201
+    title: CrewAI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - crewai
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - crewai
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses CrewAI in code but ships no agent-guidance doc (AGENTS.md or
+      CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor convention an
+      editing coding agent reads before it acts; with neither file present, any
+      agent that opens this repo has no project-specific guidance on how agents and
+      tools must be configured — in particular, whether allow_code_execution or the
+      CodeInterpreterTool are permitted, how tools must be defined and guarded, and
+      the local test and build commands. The likely consequence is generated code
+      that violates the project's safety contract because nothing in-tree teaches
+      the agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State whether code execution is permitted and under what guard, how tools must
+      be defined and constrained, any required human-in-the-loop gates, and the
+      exact test, lint, and build commands. Keep it short and concrete so an editing
+      agent can act on it without re-deriving the conventions.

--- a/crewai/shell_safety.yaml
+++ b/crewai/shell_safety.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: crewai_shell_safety
+  name: CrewAI shell-execution safety
+  category: crewai
+  description: >
+    Flags CrewAI tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution, and CrewAI ships no
+    dedicated shell-tool class, so this hand-rolled shape is the real shell
+    surface to watch.
+
+rules:
+  - id: CREW-004
+    title: CrewAI tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This CrewAI tool's body invokes a shell primitive (subprocess.*, os.system,
+      os.popen, or os.spawn*). Because the tool is exposed to the model, a
+      prompt-injected or confused model can drive it to run arbitrary commands with
+      the agent process's privileges — shell execution selected by model output is
+      the most direct path from prompt injection to remote code execution. CrewAI
+      ships no built-in shell-tool class, so a tool that shells out by hand is the
+      shell surface a reviewer must inspect.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox
+      with no ambient credentials. Keep shell logic out of any agent-callable tool.

--- a/crewai/ssrf.yaml
+++ b/crewai/ssrf.yaml
@@ -1,0 +1,33 @@
+policy:
+  id: crewai_ssrf
+  name: CrewAI SSRF safety
+  category: crewai
+  description: >
+    Flags CrewAI tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery
+    surface a model-callable tool exposes.
+
+rules:
+  - id: CREW-005
+    title: CrewAI tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This CrewAI tool issues an HTTP request whose URL is built from a parameter
+      or interpolated value rather than a fixed literal. Because the tool is
+      model-callable, the model (or a prompt injection) controls the destination —
+      it can reach internal services, the cloud metadata endpoint
+      (169.254.169.254), or localhost admin ports the agent host can see but an
+      external caller cannot. This is a classic server-side request forgery
+      primitive handed to the model.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and forbid
+      raw model-supplied URLs. If the tool only ever talks to one service, hard-code
+      the base URL and accept only a path or query from the model.

--- a/crewai/tool_behavior.yaml
+++ b/crewai/tool_behavior.yaml
@@ -1,0 +1,34 @@
+policy:
+  id: crewai_tool_behavior
+  name: CrewAI tool behavior safety
+  category: crewai
+  description: >
+    Flags CrewAI tool configuration that alters the agent's control flow in ways
+    that bypass the model's reasoning and any post-tool validation.
+
+rules:
+  - id: CREW-108
+    title: CrewAI tool returns its output as the final answer
+    severity: medium
+    confidence: 0.6
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      tool_decorator_kwarg_value:
+        kwarg: result_as_answer
+        value: "True"
+    explanation: >
+      This tool sets result_as_answer=True, so CrewAI takes the tool's raw output
+      as the agent's final answer and stops — the model never reviews the result,
+      cannot validate or summarize it, and no post-tool step runs. If the tool
+      returns model- or attacker-influenced content (a scraped page, a file read, a
+      search result), that unvalidated output flows straight to the caller. This is
+      the CrewAI analog of LangChain's return_direct: convenient for a deterministic
+      passthrough, dangerous when the tool's output is not already trusted.
+    fix: >
+      Leave result_as_answer at its default (False) unless you specifically intend
+      to short-circuit the agent with a tool whose output is already trusted and
+      sanitized. If you do use it, shape and sanitize the tool's output inside the
+      tool body, since no model step or guardrail runs after it.

--- a/crewai/tool_definition.yaml
+++ b/crewai/tool_definition.yaml
@@ -1,0 +1,54 @@
+policy:
+  id: crewai_tool_definition
+  name: CrewAI tool definition hygiene
+  category: crewai
+  description: >
+    Hygiene rules for CrewAI tools defined with the @tool decorator from
+    crewai.tools. The docstring and the parameter type hints are what CrewAI
+    turns into the tool's description and argument schema for the model.
+
+rules:
+  - id: CREW-001
+    title: CrewAI tool has no description
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      CrewAI exposes a @tool-decorated function to the model through its docstring:
+      that string becomes the tool's description in the prompt. A tool with no
+      docstring reaches the model as a bare name, so the model cannot tell what the
+      tool does or when to call it — it will skip the tool or invoke it with the
+      wrong arguments. This is the single highest-leverage authoring fix.
+    fix: >
+      Add a one-paragraph docstring to the decorated function describing what the
+      tool does, the inputs it expects, and what it returns. CrewAI passes this
+      string to the model verbatim, so write it for the model rather than a human
+      maintainer.
+
+  - id: CREW-002
+    title: CrewAI tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      CrewAI builds a tool's argument schema from the decorated function's type
+      hints. A tool whose parameters carry no annotations produces an
+      underspecified schema: the model gets no type guidance and passes arguments
+      of the wrong shape, which Pydantic then rejects at validation time — a silent
+      reliability tax on every call.
+    fix: >
+      Annotate every parameter with a concrete type (str, int, list[str], a
+      Pydantic model, etc.). CrewAI propagates these annotations into the schema the
+      model sees, so the model emits correctly-shaped arguments.

--- a/pydantic_ai/agent_safety.yaml
+++ b/pydantic_ai/agent_safety.yaml
@@ -1,0 +1,122 @@
+policy:
+  id: pydantic_ai_agent_safety
+  name: Pydantic AI agent safety
+  category: pydantic_ai
+  description: >
+    Agent-scope safety rules for Pydantic AI agents (the Agent(...) constructor).
+    These flag missing output validation, model-driven code execution and URL
+    fetching wired as native tools, and a retry strategy that re-runs an
+    already-executed tool.
+
+rules:
+  - id: PYD-101
+    title: Pydantic AI agent has no structured output validation
+    severity: low
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      any:
+        - agent_kwarg_missing:
+            - output_type
+        - agent_kwarg_value:
+            kwarg: output_type
+            value: str
+    explanation: >
+      This agent does not constrain its output to a validated type: output_type is
+      absent (defaulting to free-form str) or set explicitly to str. Pydantic AI's
+      core value is that output_type can be a Pydantic model the framework
+      validates and, on failure, asks the model to correct — turning model output
+      into a typed contract. Without it, the agent returns whatever text the model
+      produced, so downstream code parses unvalidated strings and a prompt
+      injection or a confused model can return malformed or unexpected content
+      that is consumed as if it were trusted.
+    fix: >
+      Set output_type to a Pydantic model (or a typed union) describing the
+      result the agent must return. Pydantic AI then validates each run against
+      that schema and re-prompts the model on a validation failure, so callers
+      receive a checked, typed object instead of raw text.
+
+  - id: PYD-102
+    title: Pydantic AI agent wires the code-execution native tool
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - CodeExecutionTool
+    explanation: >
+      This agent wires Pydantic AI's CodeExecutionTool (via capabilities= or
+      builtin_tools=), a provider-native tool that executes code the model
+      generates. Once it is in the tool set, a prompt injection or a confused
+      model can run attacker-chosen code in the execution environment the provider
+      grants the tool. Because the agent's instructions, tool outputs, and any
+      retrieved content are all model-reachable, this is a direct path from prompt
+      injection to arbitrary code execution.
+    fix: >
+      Remove CodeExecutionTool from production agents. If code execution is a
+      genuine requirement, run it outside the agent in a hardened sandbox (no
+      filesystem, no network, no credentials, hard timeout) and gate it behind an
+      explicit human approval rather than exposing a model-invokable code runner.
+
+  - id: PYD-103
+    title: Pydantic AI agent wires a model-driven URL-fetching native tool
+    severity: medium
+    confidence: 0.75
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - WebFetchTool
+        - UrlContextTool
+    explanation: >
+      This agent wires a native URL-fetching tool (WebFetchTool or UrlContextTool)
+      that retrieves model-chosen URLs. The model controls the destination, so a
+      prompt injection can point it at internal services, the cloud metadata
+      endpoint (169.254.169.254), or localhost admin ports the agent host can
+      reach — a server-side request forgery surface — and can also exfiltrate
+      retrieved or in-context data to an attacker-controlled URL. Pydantic AI's
+      built-in fetchers have already needed SSRF hardening (CVE-2026-46678,
+      CVE-2026-25580), so enabling one without network egress controls reintroduces
+      that exposure.
+    fix: >
+      Only enable a native fetch tool when the agent genuinely needs open web
+      access, and put network egress controls around the agent process: an
+      allow-list of permitted hosts, blocked private/link-local IP ranges, and a
+      proxy that rejects requests to internal addresses. Prefer a purpose-built
+      tool that fetches from a fixed, vetted set of endpoints over an open URL
+      fetcher.
+
+  - id: PYD-105
+    title: Pydantic AI agent retries with the exhaustive end strategy
+    severity: low
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: end_strategy
+        value: exhaustive
+    explanation: >
+      This agent sets end_strategy="exhaustive". When the model emits a final
+      result alongside still-pending tool calls, the exhaustive strategy runs
+      those remaining tool calls anyway before ending the run, instead of
+      returning immediately (the "early" default). If any of those pending calls
+      is side-effecting — a write, a charge, a send — exhaustive mode executes it
+      even though the model already considered the task done, widening the blast
+      radius of a single run and making duplicate or unintended side effects more
+      likely.
+    fix: >
+      Leave end_strategy at its "early" default so the run ends as soon as the
+      model produces a final result, skipping pending tool calls. Only choose
+      exhaustive when every tool the agent can call is side-effect-free and you
+      specifically need the remaining calls to complete.

--- a/pydantic_ai/code_execution.yaml
+++ b/pydantic_ai/code_execution.yaml
@@ -1,0 +1,32 @@
+policy:
+  id: pydantic_ai_code_execution
+  name: Pydantic AI code-execution safety
+  category: pydantic_ai
+  description: >
+    Flags Pydantic AI tools whose body evaluates code at runtime. Model-selected
+    dynamic code execution is a direct arbitrary-execution path.
+
+rules:
+  - id: PYD-004
+    title: Pydantic AI tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This Pydantic AI tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. Because the tool is exposed to the model, a
+      prompt injection can steer it to run attacker-chosen Python in the agent
+      process. This is the same arbitrary-execution capability as Pydantic AI's
+      built-in CodeExecutionTool, hand-rolled inside a tool body, and it bypasses
+      whatever sandboxing the built-in would have applied.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser
+      (ast.literal_eval for data, a typed Pydantic schema for arguments). If
+      running code is genuinely the product, isolate it in a locked-down sandbox
+      with no filesystem or network and a hard timeout.

--- a/pydantic_ai/idempotency.yaml
+++ b/pydantic_ai/idempotency.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: pydantic_ai_idempotency
+  name: Pydantic AI mutating-tool idempotency
+  category: pydantic_ai
+  description: >
+    Flags mutating tools (create/send/refund/...) without an idempotency key.
+    Pydantic AI retries tool calls under validation failures and the agent loop
+    re-invokes tools, so without a key the same side-effecting action can fire
+    twice.
+
+rules:
+  - id: PYD-007
+    title: Mutating Pydantic AI tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). Pydantic AI retries
+      a tool call when the model's arguments fail validation, and the agent loop
+      can re-select the same tool across turns; without an idempotency key the
+      same action can fire twice — a duplicate charge, a double-sent message, a
+      repeated delete. The downstream service must also honor the key for this
+      protection to be effective.
+    fix: >
+      Add an idempotency_key: str parameter and pass it through to the backing API
+      so a retried call is recognized and deduplicated rather than re-executed.

--- a/pydantic_ai/network.yaml
+++ b/pydantic_ai/network.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: pydantic_ai_network
+  name: Pydantic AI tool network hygiene
+  category: pydantic_ai
+  description: >
+    Network-call hygiene inside Pydantic AI tool functions. A tool that makes a
+    network request without a timeout can hang the agent run indefinitely.
+
+rules:
+  - id: PYD-006
+    title: Pydantic AI tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+        missing: timeout
+    explanation: >
+      This Pydantic AI tool makes a network request without a timeout, so it will
+      hang indefinitely on a slow or unresponsive remote. The tool call runs
+      inside the agent's run loop; a request with no timeout blocks that run until
+      the remote eventually responds or the connection dies, and under load this
+      ties up whatever runtime the agent is hosted on without ever surfacing the
+      failure to the model.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough to allow legitimate slow responses for
+      this endpoint, and surface failures as a structured error the model can
+      react to rather than letting the call hang.

--- a/pydantic_ai/repo_hygiene.yaml
+++ b/pydantic_ai/repo_hygiene.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: pydantic_ai_repo_hygiene
+  name: Pydantic AI repo hygiene
+  category: pydantic_ai
+  description: >
+    Repo-scoped hygiene rules for projects that use Pydantic AI. Fire once per
+    scan against the repo manifest and inventory.
+
+rules:
+  - id: PYD-201
+    title: Pydantic AI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - pydantic_ai
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - pydantic_ai
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses Pydantic AI in code but ships no agent-guidance doc
+      (AGENTS.md or CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor
+      convention an editing coding agent reads before it acts; with neither file
+      present, any agent that opens this repo has no project-specific guidance on
+      how agents and tools must be configured — in particular, whether
+      CodeExecutionTool or native URL fetchers are permitted, how tools must be
+      typed and documented, whether output_type must be a validated model, and the
+      local test and build commands. The likely consequence is generated code that
+      violates the project's safety contract because nothing in-tree teaches the
+      agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State whether code execution and open URL fetching are permitted and under
+      what guard, how tools must be defined and typed, whether structured
+      output_type is required, any human-in-the-loop gates, and the exact test,
+      lint, and build commands. Keep it short and concrete so an editing agent can
+      act on it without re-deriving the conventions.

--- a/pydantic_ai/shell_safety.yaml
+++ b/pydantic_ai/shell_safety.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: pydantic_ai_shell_safety
+  name: Pydantic AI shell-execution safety
+  category: pydantic_ai
+  description: >
+    Flags Pydantic AI tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution.
+
+rules:
+  - id: PYD-003
+    title: Pydantic AI tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This Pydantic AI tool's body invokes a shell primitive (subprocess.*,
+      os.system, os.popen, or os.spawn*). Because the tool is registered with the
+      agent and therefore model-callable, a prompt-injected or confused model can
+      drive it to run arbitrary commands with the agent process's privileges —
+      shell execution selected by model output is the most direct path from
+      prompt injection to remote code execution. The model controls both whether
+      the tool is called and the arguments it receives, so any command string
+      assembled from those arguments is attacker-influenced.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox
+      with no ambient credentials. Keep shell logic out of any agent-callable
+      tool.

--- a/pydantic_ai/ssrf.yaml
+++ b/pydantic_ai/ssrf.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: pydantic_ai_ssrf
+  name: Pydantic AI SSRF safety
+  category: pydantic_ai
+  description: >
+    Flags Pydantic AI tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery
+    surface a model-callable tool exposes.
+
+rules:
+  - id: PYD-005
+    title: Pydantic AI tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This Pydantic AI tool issues an HTTP request whose URL is built from a
+      parameter or interpolated value rather than a fixed literal. Because the
+      tool is model-callable, the model (or a prompt injection) controls the
+      destination — it can reach internal services, the cloud metadata endpoint
+      (169.254.169.254), or localhost admin ports the agent host can see but an
+      external caller cannot. This is a classic server-side request forgery
+      primitive handed to the model. Pydantic AI's own built-in URL fetchers have
+      had to harden against exactly this: CVE-2026-46678 and CVE-2026-25580
+      cover a metadata-endpoint blocklist that could be bypassed (e.g. via DNS
+      rebinding or alternate IP encodings), so a hand-rolled fetch that does no
+      validation at all is strictly more exposed.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and
+      forbid raw model-supplied URLs. Resolve the hostname and re-check the
+      resolved IP to defeat DNS rebinding. If the tool only ever talks to one
+      service, hard-code the base URL and accept only a path or query from the
+      model.

--- a/pydantic_ai/tool_definition.yaml
+++ b/pydantic_ai/tool_definition.yaml
@@ -1,0 +1,64 @@
+policy:
+  id: pydantic_ai_tool_definition
+  name: Pydantic AI tool definition hygiene
+  category: pydantic_ai
+  description: >
+    Hygiene rules for Pydantic AI tools defined with the @agent.tool /
+    @agent.tool_plain decorators or the Tool(...) factory. Pydantic AI builds the
+    tool's description from the function docstring and its argument schema from
+    the parameter type hints, so a missing docstring or untyped parameters
+    degrade exactly what the model sees.
+
+rules:
+  - id: PYD-001
+    title: Pydantic AI tool has no description
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      Pydantic AI turns a tool function's docstring into the tool description it
+      sends to the model. A tool with no docstring reaches the model as a bare
+      name with no guidance on what it does or when to call it, so the model
+      skips it or invokes it with the wrong arguments. The docstring is also where
+      Pydantic AI extracts per-parameter descriptions (it parses Google/NumPy/
+      Sphinx styles), so an absent docstring strips both the tool- and
+      argument-level guidance at once.
+    fix: >
+      Add a docstring to the tool function describing what it does, the inputs it
+      expects, and what it returns. Pydantic AI passes this to the model verbatim
+      and parses the parameter sections into the argument schema, so write it for
+      the model rather than only a human maintainer.
+
+  - id: PYD-002
+    title: Pydantic AI tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      Pydantic AI builds a tool's JSON argument schema from the function's
+      parameter type hints. A tool whose parameters carry no annotations produces
+      an underspecified schema: the model gets no type guidance and emits
+      arguments of the wrong shape, which Pydantic then rejects at validation
+      time — a silent reliability tax on every call, and on a retrying agent a
+      source of wasted turns. Note for reviewers: a context tool's leading
+      ctx: RunContext[...] parameter is itself typed, so an @agent.tool whose
+      business parameters are untyped but whose ctx is annotated may not be
+      flagged here (a false negative, never a false positive); @agent.tool_plain
+      tools and no-arg tools are unaffected.
+    fix: >
+      Annotate every business parameter with a concrete type (str, int,
+      list[str], a Pydantic model, etc.). Pydantic AI propagates these
+      annotations into the schema the model sees, so the model emits
+      correctly-shaped arguments and validation stops rejecting them.

--- a/vercel_ai/agent_safety.yaml
+++ b/vercel_ai/agent_safety.yaml
@@ -1,0 +1,110 @@
+policy:
+  id: vercel_ai_agent_safety
+  name: Vercel AI SDK agent safety
+  category: vercel_ai
+  description: >
+    Agent-scope safety rules for Vercel AI SDK agents — the generateText /
+    streamText / generateObject / streamObject tool-loop calls and the
+    ToolLoopAgent class. These flag agents wired with provider tools that hand
+    the model shell, computer-control, or code-execution reach, and agents whose
+    tool loop has no bound, the two ways a Vercel agent turns a prompt injection
+    into runaway or arbitrary execution.
+
+rules:
+  - id: VAI-006
+    title: Vercel AI agent wires a provider shell / computer / code-execution tool
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - vercel_ai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - anthropic.tools.bash
+        - anthropic.tools.computer
+        - anthropic.tools.codeExecution
+        - openai.tools.localShell
+        - openai.tools.computerUsePreview
+        - openai.tools.codeInterpreter
+        - google.tools.codeExecution
+    explanation: >
+      This agent's tools record includes a Vercel-provider tool that gives the
+      model shell, full computer control, or a code interpreter — anthropic's
+      bash / computer / codeExecution, openai's localShell / computerUsePreview /
+      codeInterpreter, or google's codeExecution. The Vercel AI SDK ships and
+      markets these provider tools as first-class, so wiring one is a single line
+      that hands a model-driven loop direct execution on the host or sandbox.
+      Because the agent's prompts and prior tool outputs are model-reachable, a
+      prompt injection has a direct path to running attacker-chosen commands or
+      code with the agent's privileges.
+    fix: >
+      Drop the provider execution tool unless the workflow truly requires it. If
+      it is essential, run it against an isolated, ephemeral sandbox with no
+      credentials, no private-network reach, and a hard timeout; constrain which
+      commands or code may run; and gate every invocation behind an explicit
+      human approval rather than letting the tool loop call it autonomously.
+
+  - id: VAI-007
+    title: Vercel AI agent tool loop has no step bound
+    severity: medium
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - vercel_ai_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_missing:
+            - stopWhen
+        - agent_kwarg_missing:
+            - maxSteps
+    explanation: >
+      This agent runs a multi-step tool loop (generateText / streamText /
+      ToolLoopAgent with a tools record) but sets neither stopWhen nor maxSteps,
+      so the loop's only stopping condition is the model deciding to stop calling
+      tools. A prompt injection or a model that loops on a tool whose output keeps
+      re-triggering it can run the loop unbounded — burning tokens, hammering the
+      wired tools (including any side-effecting or billed ones), and stalling the
+      request. The SDK does not impose a default ceiling.
+    fix: >
+      Set an explicit bound: pass maxSteps (a small integer ceiling on tool
+      round-trips) or a stopWhen condition (e.g. stepCountIs(n) or a predicate
+      that ends the loop once the task is done). Choose the lowest bound the
+      workflow tolerates so a misbehaving loop fails fast instead of running away.
+
+  - id: VAI-008
+    title: Vercel AI agent forces a provider execution tool every step
+    severity: medium
+    confidence: 0.65
+    language: typescript
+    applies_to:
+      - vercel_ai_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_value:
+            kwarg: toolChoice
+            value: required
+        - agent_uses_hosted_tool_class:
+            - anthropic.tools.bash
+            - anthropic.tools.computer
+            - anthropic.tools.codeExecution
+            - openai.tools.localShell
+            - openai.tools.computerUsePreview
+            - openai.tools.codeInterpreter
+            - google.tools.codeExecution
+    explanation: >
+      This agent sets toolChoice: "required" while wiring a provider shell /
+      computer / code-execution tool. "required" forces the model to call a tool
+      on every step instead of letting it answer directly, so the high-risk
+      execution tool is far more likely to be invoked — and on a step the model
+      had no real need for it. Combined with a model-reachable prompt surface,
+      forcing a tool call narrows the model's options toward exactly the
+      capability you least want it reaching for.
+    fix: >
+      Use toolChoice: "auto" (the default) so the model calls the execution tool
+      only when the task needs it, or pin toolChoice to a specific safe tool when
+      a call is genuinely mandatory. Keep shell / computer / code-execution tools
+      out of any agent that forces a tool call, and gate their use behind an
+      explicit approval.

--- a/vercel_ai/code_execution.yaml
+++ b/vercel_ai/code_execution.yaml
@@ -1,0 +1,33 @@
+policy:
+  id: vercel_ai_code_execution
+  name: Vercel AI SDK code-execution safety
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() body evaluates code with eval or
+    the Function constructor. Either turns model-supplied text into executing
+    code with no sandbox.
+
+rules:
+  - id: VAI-002
+    title: Vercel AI tool execute() evaluates code (eval / new Function)
+    severity: high
+    confidence: 0.9
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler calls eval(...) or constructs
+      a function with new Function(...). Because the tool is model-callable, a
+      string the model emits becomes executing JavaScript in the agent process —
+      a single prompt injection yields arbitrary code execution with no sandbox
+      between the model and the host. This is strictly more dangerous than a
+      shell-out: there is not even a separate process boundary to constrain.
+    fix: >
+      Remove eval / new Function from the tool. If the tool must interpret a
+      model-provided expression, parse it with a real parser into a constrained
+      AST you evaluate yourself, or hand it to an isolated sandbox (a separate
+      process or a hardened runner with no filesystem, network, or credentials)
+      gated behind an explicit allow-list. Never feed model output to eval.

--- a/vercel_ai/repo_hygiene.yaml
+++ b/vercel_ai/repo_hygiene.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: vercel_ai_repo_hygiene
+  name: Vercel AI SDK repo hygiene
+  category: vercel_ai
+  description: >
+    Repo-scoped hygiene rules for projects that use the Vercel AI SDK. Fire once
+    per scan against the repo manifest and inventory.
+
+rules:
+  - id: VAI-012
+    title: Vercel AI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - vercel_ai
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - vercel_ai
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses the Vercel AI SDK in code but ships no agent-guidance doc
+      (AGENTS.md or CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor
+      convention an editing coding agent reads before it acts; with neither file
+      present, any agent that opens this repo has no project-specific guidance on
+      how tools and agents must be configured — in particular, whether provider
+      execution tools (anthropic bash/computer, openai localShell/codeInterpreter)
+      are permitted, how tools must be typed and guarded, and the local test and
+      build commands. The likely consequence is generated code that violates the
+      project's safety contract because nothing in-tree teaches the agent the
+      local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State whether provider execution tools are permitted and under what guard,
+      how tools must be defined and constrained, any required human-in-the-loop
+      gates, and the exact test, lint, and build commands. Keep it short and
+      concrete so an editing agent can act on it without re-deriving the
+      conventions.

--- a/vercel_ai/shell_safety.yaml
+++ b/vercel_ai/shell_safety.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: vercel_ai_shell_safety
+  name: Vercel AI SDK shell-execution safety
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() body shells out to the operating
+    system. A model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution. The Vercel AI SDK ships
+    no dedicated shell-tool primitive in the `ai` core, so a hand-rolled
+    execute() that spawns a subprocess is the real shell surface to watch.
+
+rules:
+  - id: VAI-001
+    title: Vercel AI tool execute() spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler invokes a Node shell primitive
+      (child_process exec / execSync / spawn / spawnSync / execFile / fork).
+      Because the tool is exposed to the model via the agent's tools record, a
+      prompt-injected or confused model can drive it to run arbitrary commands
+      with the agent process's privileges — shell execution selected by model
+      output is the most direct path from prompt injection to remote code
+      execution. The `ai` package has no built-in shell tool, so a tool that
+      shells out by hand is the shell surface a reviewer must inspect.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace the shell-out with
+      a typed library call; if a subprocess is unavoidable, use execFile with a
+      fixed argument list (never a shell string), allow-list the exact commands,
+      and run it in a sandbox with no ambient credentials. Keep shell logic out
+      of any model-callable tool.

--- a/vercel_ai/ssrf.yaml
+++ b/vercel_ai/ssrf.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: vercel_ai_ssrf
+  name: Vercel AI SDK server-side request forgery
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() body fetches a URL the model
+    controls. A model-chosen request target is a server-side request forgery
+    vector into internal services and the cloud metadata endpoint.
+
+rules:
+  - id: VAI-003
+    title: Vercel AI tool execute() fetches a model-controlled URL
+    severity: high
+    confidence: 0.75
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler issues an outbound HTTP call
+      (fetch / axios / got / undici) whose URL is not a constant — it comes from
+      the tool's arguments, a template string, or a concatenation, all of which
+      the model controls at call time. A prompt injection can point the request
+      at internal services or the cloud metadata endpoint (169.254.169.254) to
+      exfiltrate credentials, and the fetched body then re-enters the
+      conversation as untrusted text, opening a second-order prompt-injection
+      channel.
+    fix: >
+      Do not let the model choose the request target. Validate the URL against an
+      allow-list of permitted hosts, reject private and link-local IP ranges
+      (and redirects into them), and forbid raw model-supplied URLs. Treat any
+      retrieved content as untrusted — keep it out of the system prompt and do
+      not let it expand the agent's permissions.

--- a/vercel_ai/tool_definition.yaml
+++ b/vercel_ai/tool_definition.yaml
@@ -1,0 +1,60 @@
+policy:
+  id: vercel_ai_tool_definition
+  name: Vercel AI SDK tool definition hygiene
+  category: vercel_ai
+  description: >
+    Hygiene rules for Vercel AI SDK tools built with tool({...}) / dynamicTool({...})
+    from the `ai` package. The `description` is the only model-visible account of
+    what the tool does (the SDK has no docstring fallback), and the inputSchema
+    is what the SDK turns into the model's argument schema.
+
+rules:
+  - id: VAI-004
+    title: Vercel AI tool has no description
+    severity: low
+    confidence: 0.9
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      The Vercel AI SDK exposes a tool to the model through its `description`
+      field — that string is the entire account of what the tool does in the
+      prompt. Unlike Python frameworks there is no docstring fallback, so a tool
+      defined with no `description` (or an empty one) reaches the model as a bare
+      name: the model cannot tell what the tool does or when to call it, and it
+      will skip the tool or invoke it with the wrong arguments. This is the
+      single highest-leverage authoring fix.
+    fix: >
+      Add a `description` to the tool({...}) options describing what the tool
+      does, the inputs it expects, and what it returns. The SDK passes this
+      string to the model verbatim, so write it for the model rather than a human
+      maintainer.
+
+  - id: VAI-005
+    title: Vercel AI tool accepts untyped input
+    severity: medium
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      The Vercel AI SDK builds a tool's argument schema from its inputSchema (or
+      the v4 `parameters`). This tool takes input but imposes no field types — it
+      either uses dynamicTool (whose input is always `unknown`) or an open schema
+      (z.any(), z.unknown(), or an empty z.object({})). The model then gets no
+      argument-shape guidance and passes values of the wrong shape, which the SDK
+      rejects at validation time or, worse, forwards unchecked into execute() — a
+      reliability and injection tax on every call.
+    fix: >
+      Give the tool a concrete Zod object schema in inputSchema with a typed
+      field per argument (z.object({ city: z.string(), units: z.enum([...]) })).
+      Reserve dynamicTool for the rare case where the input genuinely cannot be
+      typed, and even then validate the shape inside execute() before using it.


### PR DESCRIPTION
## Summary

Adds four new SDK rule packs — **CrewAI** (14, `CREW-*`), **AutoGen/AG2** (12, `AG2-*`), **Vercel AI SDK** (9, `VAI-*`), and **Pydantic AI** (12, `PYD-*`) — 47 rules, taking the production pack from 117 to 164.

Each pack covers tool/agent/repo scopes with house-style `explanation`/`fix` text; the code-execution and SSRF rules are CVE-grounded (CrewAI CVE-2026-2275/2287/2286/2285; Pydantic CVE-2026-46678/25580). `schema_version` stays **8** — every rule reuses an existing predicate, so no engine schema change.

These mirror the engine's `testdata/rules-fixture/` exactly; the `rules-sync` CI guard (now category-discovery-dynamic) enforces byte-parity.

## Companion PRs

- **trustabl/trustabl#20** — engine discovery + shared spine.
- **trustabl-rulebook** — the 30 paired rationale docs.

_No Jira ticket supplied; add `Refs: TR-XXX` if one applies._
