### PR TITLE
feat(rules): new-SDK packs + TS timeout (OAI-016 structural, VAI-011)

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,11 +1,14 @@
 # Trustabl rules pack manifest.
 #
-# schema_version is the rule-schema contract this pack targets. The Trustabl
-# engine (internal/rules.SupportedSchemaVersion) refuses a pack whose
-# schema_version exceeds what it can evaluate, so a newer pack never silently
-# misloads against an older binary. Bump this in lockstep with any engine
-# change that adds a predicate or schema field.
+# schema_version is the rule-schema contract this pack targets. With
+# forward-compatible loading, the Trustabl engine
+# (internal/rules.SupportedSchemaVersion) no longer refuses a pack whose
+# schema_version exceeds what it understands — it loads the pack leniently,
+# skipping only the rules that reference predicates it lacks, and warns. Bump
+# this in lockstep with any engine change that adds a predicate or schema field:
+# the bump advertises the pack's level and drives the "rules newer than this
+# build" warning rather than gating older binaries out of the whole pack.
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 8
+schema_version: 9

--- a/openai_sdk/network.yaml
+++ b/openai_sdk/network.yaml
@@ -77,27 +77,17 @@ rules:
       - openai_tool
     scope: tool
     match:
-      all:
-        - has_body_text:
-            - fetch(
-        - not:
-            has_body_text:
-              - AbortSignal
-              - AbortController
-              - 'signal:'
-              - AbortSignal.timeout
+      has_http_call_without_timeout: true
     explanation: >
-      An OpenAI Agents SDK tool authored in TypeScript calls `fetch()` without
-      attaching an AbortSignal. Node's and the browser's `fetch` have no
-      implicit timeout; a slow or unresponsive host blocks the tool's
+      An OpenAI Agents SDK tool authored in TypeScript makes an HTTP call
+      (`fetch` / `axios` / `got`) without a timeout bound — no `signal`,
+      `timeout`, or `abortSignal` option. Node's and the browser's `fetch`
+      have no implicit timeout; a slow or unresponsive host blocks the tool's
       `execute` callback indefinitely, which in turn blocks the agent's run
       loop, consumes the conversation's wall-clock budget, and ties up the
-      worker that owns the request. The miner's examples include Cloudflare
-      Worker and realtime-agent templates that fetch from URLs interpolated
-      from tool arguments, so the gap also amplifies SSRF and exfiltration
-      impact: the call cannot be cancelled even when downstream behaviour
-      goes obviously wrong. Provisional: this rule loads and validates today
-      but will not fire until the engine's TypeScript tool parser ships.
+      worker that owns the request. Tools that fetch URLs interpolated from
+      tool arguments also amplify SSRF and exfiltration impact: the call
+      cannot be cancelled even when downstream behaviour goes obviously wrong.
     fix: >
       Attach an AbortSignal that fires after a bounded deadline. Modern
       runtimes: `await fetch(url, { signal: AbortSignal.timeout(15_000) })`.

--- a/vercel_ai/network.yaml
+++ b/vercel_ai/network.yaml
@@ -1,0 +1,38 @@
+policy:
+  id: vercel_ai_network
+  name: Vercel AI SDK network safety
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() body makes an outbound HTTP call
+    with no timeout, so a slow or unresponsive host can hang the agent's tool
+    loop indefinitely.
+
+rules:
+  - id: VAI-011
+    title: Vercel AI tool HTTP call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler makes an outbound HTTP call
+      (fetch / axios / got / undici) without a timeout bound — no `signal`,
+      `timeout`, or `abortSignal` option. Node's `fetch` has no implicit
+      deadline, so a slow or unresponsive host blocks the tool callback
+      indefinitely; because the call sits inside the model's tool loop, it ties
+      up the request worker and burns the conversation's wall-clock budget with
+      no way to cancel. The risk compounds with VAI-003: a model-controlled URL
+      that also cannot time out can be steered at an internal host that simply
+      never responds.
+    fix: >
+      Attach a deadline. Modern runtimes:
+      `await fetch(url, { signal: AbortSignal.timeout(15_000) })`. For older
+      runtimes, create an `AbortController`, call `controller.abort()` from a
+      `setTimeout`, pass `controller.signal`, and clear the timer in a
+      `finally`. axios and got take a `timeout` option directly. Surface the
+      resulting abort as a structured tool error the model can react to rather
+      than letting the turn hang.


### PR DESCRIPTION
⚠️ **Merge order:** deploy the engine release that adds forward-compatible loading + schema-9 support **before** merging this. This bumps the production pack to `schema_version: 9`; a binary predating forward-compatible loading hard-fails on a v9 pack. Once the forward-compatible engine is deployed, older binaries degrade gracefully (skip the rules they cannot evaluate + warn).

## Contents
This branch (`cf/new-sdk-coverage`) brings the rules pack in line with engine `main` (whose discovery for these SDKs already merged via trustabl/trustabl#20) and carries two units of work:

1. **New-SDK rule packs** (prior, previously unmerged): CrewAI, AutoGen/AG2, Vercel AI, Pydantic AI.
2. **TS network-timeout** (new): retrofit OAI-016 from the brittle `has_body_text` substring match to the engine's structural `has_http_call_without_timeout` predicate, and add **VAI-011** (Vercel AI tool HTTP call has no timeout). Bumps `schema_version` 8 → 9.

## Verification
Mirrored into the engine's `testdata/rules-fixture/` and validated by `go test ./...` (per-rule fire/silent harness) + `scripts/check-rules-sync.sh` (fixture ↔ production in sync, 84 files). Rulebook rationale in the paired `trustabl-rulebook` PR.
