### PR TITLE
feat(mcp): language:go rules MCP-015 / MCP-016

### DIFF
--- a/mcp/tool_definition.yaml
+++ b/mcp/tool_definition.yaml
@@ -102,3 +102,55 @@ rules:
     fix: >
       Provide a concise `description` string in the registration config stating
       what the tool does and when a model should call it.
+
+  - id: MCP-015
+    title: Go MCP tool has no description
+    severity: low
+    confidence: 0.85
+    language: go
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      An MCP server authored in Go advertises each tool's description to
+      connecting clients as the text a model uses to decide whether to call it. A
+      `mcp.NewTool("name", ...)` with no `mcp.WithDescription(...)` option (or an
+      `mcp.Tool{...}` whose `Description` is empty) gives every connecting model
+      nothing to route on, causing wrong-tool or skipped calls across all clients
+      of the server.
+    fix: >
+      Add `mcp.WithDescription("...")` to the `mcp.NewTool(...)` call (mark3labs/
+      mcp-go), or set the `Description` field on the `mcp.Tool` value (the
+      official go-sdk), stating what the tool does and when a model should call
+      it.
+
+  - id: MCP-016
+    title: Ambiguous Go MCP tool name
+    severity: low
+    confidence: 0.85
+    language: go
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - thing
+        - stuff
+    explanation: >
+      A Go MCP tool's name is the first argument to `mcp.NewTool(...)` (or the
+      `Name` field of an `mcp.Tool`). Names like `process`, `handle`, or `run`
+      give a connecting model no signal about intent. Because an MCP server is
+      consumed by clients the author does not control, an ambiguous name degrades
+      tool selection everywhere the server is mounted and collides more easily
+      with similarly-named tools from other servers in the same session.
+    fix: >
+      Rename to a verb-object form, e.g. `summarize_invoice`, `fetch_weather`.


### PR DESCRIPTION
## Summary

Field-based `language: go` MCP rules, paired with the engine's new tree-sitter-go MCP discovery and the rulebook rationale doc (same branch name in both repos).

- **MCP-015** — Go MCP tool has no description (`has_docstring: false`).
- **MCP-016** — Ambiguous Go MCP tool name (`name_in`).

Both reuse existing field predicates (no engine predicate changes). They cover mark3labs/mcp-go (`mcp.NewTool(...)`) and the official go-sdk (`mcp.AddTool(server, &mcp.Tool{...}, fn)`). Untyped-params has no Go analog (Go is statically typed).
