### PR TITLE
feat(mcp): language:csharp rules MCP-017 / MCP-018

### DIFF
--- a/mcp/tool_definition.yaml
+++ b/mcp/tool_definition.yaml
@@ -154,3 +154,54 @@ rules:
       with similarly-named tools from other servers in the same session.
     fix: >
       Rename to a verb-object form, e.g. `summarize_invoice`, `fetch_weather`.
+
+  - id: MCP-017
+    title: C# MCP tool has no description
+    severity: low
+    confidence: 0.85
+    language: csharp
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      A C# MCP server advertises each tool's description to connecting clients as
+      the text a model uses to decide whether to call it. An `[McpServerTool]`
+      method with no co-located `[Description("...")]` attribute advertises no
+      routing signal, causing wrong-tool or skipped calls across every client of
+      the server.
+    fix: >
+      Add a `[Description("...")]` attribute (System.ComponentModel) to the
+      `[McpServerTool]` method, stating what the tool does and when a model
+      should call it.
+
+  - id: MCP-018
+    title: Ambiguous C# MCP tool name
+    severity: low
+    confidence: 0.85
+    language: csharp
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - thing
+        - stuff
+    explanation: >
+      A C# MCP tool's name defaults to the `[McpServerTool]` method name. Names
+      like `Process`, `Handle`, or `Run` give a connecting model no signal about
+      intent. Because an MCP server is consumed by clients the author does not
+      control, an ambiguous name degrades tool selection everywhere the server is
+      mounted and collides more easily with similarly-named tools from other
+      servers in the same session.
+    fix: >
+      Rename the method (or set `[McpServerTool(Name = "...")]`) to a verb-object
+      form, e.g. `SummarizeInvoice`, `FetchWeather`.

--- a/mcp/tool_definition.yaml
+++ b/mcp/tool_definition.yaml
@@ -102,3 +102,55 @@ rules:
     fix: >
       Provide a concise `description` string in the registration config stating
       what the tool does and when a model should call it.
+
+  - id: MCP-015
+    title: Go MCP tool has no description
+    severity: low
+    confidence: 0.85
+    language: go
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      An MCP server authored in Go advertises each tool's description to
+      connecting clients as the text a model uses to decide whether to call it. A
+      `mcp.NewTool("name", ...)` with no `mcp.WithDescription(...)` option (or an
+      `mcp.Tool{...}` whose `Description` is empty) gives every connecting model
+      nothing to route on, causing wrong-tool or skipped calls across all clients
+      of the server.
+    fix: >
+      Add `mcp.WithDescription("...")` to the `mcp.NewTool(...)` call (mark3labs/
+      mcp-go), or set the `Description` field on the `mcp.Tool` value (the
+      official go-sdk), stating what the tool does and when a model should call
+      it.
+
+  - id: MCP-016
+    title: Ambiguous Go MCP tool name
+    severity: low
+    confidence: 0.85
+    language: go
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - thing
+        - stuff
+    explanation: >
+      A Go MCP tool's name is the first argument to `mcp.NewTool(...)` (or the
+      `Name` field of an `mcp.Tool`). Names like `process`, `handle`, or `run`
+      give a connecting model no signal about intent. Because an MCP server is
+      consumed by clients the author does not control, an ambiguous name degrades
+      tool selection everywhere the server is mounted and collides more easily
+      with similarly-named tools from other servers in the same session.
+    fix: >
+      Rename to a verb-object form, e.g. `summarize_invoice`, `fetch_weather`.


### PR DESCRIPTION
## Summary

Field-based `language: csharp` MCP rules for the official ModelContextProtocol C# SDK's `[McpServerTool]` methods, paired with the engine's tree-sitter-c-sharp discovery and the rulebook rationale (same branch name across repos).

- **MCP-017** — C# MCP tool has no description (`has_docstring: false`, reads the co-located `[Description(...)]`).
- **MCP-018** — Ambiguous C# MCP tool name (`name_in`, case-insensitive so PascalCase `Process` matches).

Both reuse existing field predicates (no engine predicate changes). Untyped-params has no C# analog (statically typed).

**Stacked on #16** (Go rules): until #16 merges, this PR's diff also shows the Go MCP-015/016 rows.
