### PR TITLE
feat(mcp): re-add Go/C#/PHP/Rust tool-definition rules (MCP-015..022)

### DIFF
--- a/mcp/tool_definition.yaml
+++ b/mcp/tool_definition.yaml
@@ -154,3 +154,158 @@ rules:
       with similarly-named tools from other servers in the same session.
     fix: >
       Rename to a verb-object form, e.g. `summarize_invoice`, `fetch_weather`.
+
+  - id: MCP-017
+    title: C# MCP tool has no description
+    severity: low
+    confidence: 0.85
+    language: csharp
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      A C# MCP server advertises each tool's description to connecting clients as
+      the text a model uses to decide whether to call it. An `[McpServerTool]`
+      method with no co-located `[Description("...")]` attribute advertises no
+      routing signal, causing wrong-tool or skipped calls across every client of
+      the server.
+    fix: >
+      Add a `[Description("...")]` attribute (System.ComponentModel) to the
+      `[McpServerTool]` method, stating what the tool does and when a model
+      should call it.
+
+  - id: MCP-018
+    title: Ambiguous C# MCP tool name
+    severity: low
+    confidence: 0.85
+    language: csharp
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - thing
+        - stuff
+    explanation: >
+      A C# MCP tool's name defaults to the `[McpServerTool]` method name. Names
+      like `Process`, `Handle`, or `Run` give a connecting model no signal about
+      intent. Because an MCP server is consumed by clients the author does not
+      control, an ambiguous name degrades tool selection everywhere the server is
+      mounted and collides more easily with similarly-named tools from other
+      servers in the same session.
+    fix: >
+      Rename the method (or set `[McpServerTool(Name = "...")]`) to a verb-object
+      form, e.g. `SummarizeInvoice`, `FetchWeather`.
+
+  - id: MCP-019
+    title: PHP MCP tool has no description
+    severity: low
+    confidence: 0.85
+    language: php
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      A PHP MCP server advertises each tool's description to connecting clients
+      as the text a model uses to decide whether to call it. A `#[McpTool]`
+      attribute with no `description:` argument advertises no routing signal,
+      causing wrong-tool or skipped calls across every client of the server.
+    fix: >
+      Add a `description:` argument to the `#[McpTool]` attribute, e.g.
+      `#[McpTool(description: '...')]`, stating what the tool does and when a
+      model should call it.
+
+  - id: MCP-020
+    title: Ambiguous PHP MCP tool name
+    severity: low
+    confidence: 0.85
+    language: php
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - thing
+        - stuff
+    explanation: >
+      A PHP MCP tool's name is the `#[McpTool]` attribute's `name:` argument, or
+      the method name when that argument is omitted. Names like `process`,
+      `handle`, or `run` give a connecting model no signal about intent. Because
+      an MCP server is consumed by clients the author does not control, an
+      ambiguous name degrades tool selection everywhere the server is mounted and
+      collides more easily with similarly-named tools from other servers in the
+      same session.
+    fix: >
+      Rename the method (or set the `#[McpTool]` `name:` argument) to a
+      verb-object form, e.g. `summarize_invoice`, `fetch_weather`.
+
+  - id: MCP-021
+    title: Rust MCP tool has no description
+    severity: low
+    confidence: 0.85
+    language: rust
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      A Rust MCP server (the official rmcp crate) advertises each tool's
+      description to connecting clients as the text a model uses to decide
+      whether to call it. The rmcp `#[tool]` macro derives that description from
+      either a `description = "..."` attribute argument or the method's `///`
+      doc comment; when neither is present the tool ships with no routing signal,
+      causing wrong-tool or skipped calls across every client of the server.
+    fix: >
+      Add a `description = "..."` argument to the `#[tool(...)]` attribute, or a
+      `///` doc comment on the method, stating what the tool does and when a
+      model should call it.
+
+  - id: MCP-022
+    title: Ambiguous Rust MCP tool name
+    severity: low
+    confidence: 0.85
+    language: rust
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - thing
+        - stuff
+    explanation: >
+      A Rust MCP tool's name is the `#[tool]` attribute's `name = "..."` argument,
+      or the method name when that argument is omitted. Names like `process`,
+      `handle`, or `run` give a connecting model no signal about intent. Because
+      an MCP server is consumed by clients the author does not control, an
+      ambiguous name degrades tool selection everywhere the server is mounted and
+      collides more easily with similarly-named tools from other servers in the
+      same session.
+    fix: >
+      Rename the method (or set the `#[tool]` `name = "..."` argument) to a
+      verb-object form, e.g. `summarize_invoice`, `fetch_weather`.


### PR DESCRIPTION
**DRAFT / DO NOT MERGE YET.** Re-adds the language packs to the full pre-incident state (MCP-001..022). Pairs with #23 (drop orphaned go): once #23 merges, this PR's diff becomes **+MCP-015..022 (all four languages)**; until then it shows +MCP-017..022 because go is still on main.

## ⚠️ Why this is a draft
Merging while v0.1.3 is still supported **re-breaks it** — v0.1.3 hard-fails its entire rule load on `language: csharp/php/rust`, and there is no forward-compatible release or compat gate live yet. This is the exact incident the hotfix fixed.

## Merge prerequisites (in order)
1. Merge **#23** (drop orphaned go) so main is at a clean pre-language baseline.
2. Merge engine [#35](https://github.com/trustabl/trustabl/pull/35) (forward-compatible language loader) and **cut v0.1.4**.
3. Publish v0.1.4's descriptor: `trustabl capabilities > compat/v0.1.4.json` (reports `hard_fail_dimensions: []`).
4. Merge the compat gate [#21](https://github.com/trustabl/trustabl-rules/pull/21). Until step 5 it will (correctly) fail this PR.
5. Remove `compat/v0.1.3.json` — the explicit decision to drop v0.1.3 from support. Then the gate goes green and this is safe to merge.

## Merge as a 3-repo set (CI coherence)
Land together with the paired PRs or `rules-sync` / the rulebook gate go red:
- engine discovery + fixture: [#30 go](https://github.com/trustabl/trustabl/pull/30), [#31 csharp](https://github.com/trustabl/trustabl/pull/31), [#32 php](https://github.com/trustabl/trustabl/pull/32), [#33 rust](https://github.com/trustabl/trustabl/pull/33)
- rulebook docs: [#11 go](https://github.com/trustabl/trustabl-rulebook/pull/11), [#12 csharp](https://github.com/trustabl/trustabl-rulebook/pull/12), [#13 php](https://github.com/trustabl/trustabl-rulebook/pull/13), [#14 rust](https://github.com/trustabl/trustabl-rulebook/pull/14)