### PR TITLE
feat(claude_skill): skill-safety CSKILL pack + bundled-script rules

### DIFF
--- a/claude_skill/skill_safety.yaml
+++ b/claude_skill/skill_safety.yaml
@@ -102,14 +102,16 @@ rules:
       skill_body_has_injection_marker: true
     explanation: >
       This skill's body carries a prompt-injection signal — instruction-override
-      phrasing ("ignore previous instructions"), zero-width characters used to
-      smuggle hidden text, or a long base64 blob that may conceal instructions.
-      Because the skill description and body enter Claude's context, an injected
-      instruction here can hijack the agent.
+      phrasing ("ignore previous instructions"), invisible Unicode used to smuggle
+      hidden text (zero-width characters, the Unicode Tags block U+E0000–E007F, or
+      bidirectional overrides), or a long base64 blob that may conceal
+      instructions. Because the skill description and body enter Claude's context,
+      an injected instruction here — including one a human reviewer cannot see —
+      can hijack the agent.
     fix: >
-      Remove the override phrasing, zero-width characters, or encoded blob. A
-      legitimate skill states its guidance in plain, visible text; it never needs
-      to override prior instructions or hide content from review.
+      Remove the override phrasing, the invisible/smuggling characters, or the
+      encoded blob. A legitimate skill states its guidance in plain, visible text;
+      it never needs to override prior instructions or hide content from review.
 
   - id: CSKILL-050
     title: Model-invocable skill grants side-effecting tools
@@ -137,3 +139,48 @@ rules:
       Add `disable-model-invocation: true` so only the user can invoke this skill,
       or narrow allowed-tools to read-only tools (Read, Grep, Glob). Reserve
       auto-invocation for skills that carry knowledge, not side effects.
+
+  - id: CSKILL-010
+    title: Bundled skill script performs network egress
+    severity: high
+    confidence: 0.7
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_bundled_script_network_egress: true
+    explanation: >
+      A script bundled in this skill's directory makes outbound network calls
+      (curl / wget / nc / …). A skill can run its bundled scripts via Bash, and a
+      scanner that only reads SKILL.md never sees this — the payload hides in an
+      auxiliary or "test" file. On its own an egress call may load remote code
+      (curl piped into a shell); paired with credential access in the same script
+      it becomes data exfiltration that runs on your machine when the skill is
+      activated.
+    fix: >
+      Remove network calls from bundled scripts, or gate them behind an explicit,
+      reviewed, user-approved step. Treat every bundled script as code that runs
+      with your privileges: pin and review what it fetches, and never let it pipe
+      a remote response straight into a shell.
+
+  - id: CSKILL-011
+    title: Bundled skill script reads credentials or secrets
+    severity: critical
+    confidence: 0.8
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_bundled_script_reads_secrets: true
+    explanation: >
+      A script bundled with this skill reads credentials or secrets (gh auth,
+      $AWS_*, ~/.aws, ~/.ssh, id_rsa, *_key, …). Because a skill can run its
+      bundled scripts, this is a credential-theft primitive hidden outside
+      SKILL.md — exactly the aux/test-file payload that body-only scanners miss.
+      Combined with a network call in the same script it is direct credential
+      exfiltration.
+    fix: >
+      Remove credential and secret access from bundled scripts. If the skill
+      legitimately needs a secret, have the user provide it through an explicit,
+      auditable runtime prompt — never read it from a bundled script that runs
+      automatically when the skill is activated.

--- a/claude_skill/skill_safety.yaml
+++ b/claude_skill/skill_safety.yaml
@@ -1,0 +1,139 @@
+policy:
+  id: claude_skill_safety
+  name: Claude Agent Skill safety
+  category: claude_skill
+  description: >
+    High-risk patterns in Claude Code Agent Skills (SKILL.md): auto-approved
+    shell, pre-model dynamic-context execution, exfiltration primitives, and
+    prompt-injection signals. Skill rules audit SKILL.md frontmatter + body and
+    are language-agnostic (markdown), so they carry no language: field.
+
+rules:
+  - id: CSKILL-001
+    title: Skill auto-approves unrestricted shell
+    severity: critical
+    confidence: 0.95
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_allows_unrestricted_shell: true
+    explanation: >
+      This skill's allowed-tools pre-approves unrestricted shell — a bare `Bash`
+      grant or `Bash(*)`. In Claude Code allowed-tools is an auto-approval list,
+      not a sandbox: while the skill is active Claude runs any shell command it
+      lists WITHOUT prompting you. Combined with a skill's ability to run bundled
+      scripts and dynamic-context commands, this is effectively arbitrary local
+      code execution on activation.
+    fix: >
+      Replace the wildcard with the specific commands the skill needs, e.g.
+      `allowed-tools: Bash(git status *) Bash(git diff *)`. Never grant `Bash(*)`
+      or a bare `Bash` in a skill checked into a shared repository.
+
+  - id: CSKILL-002
+    title: Skill runs shell during load (dynamic-context execution)
+    severity: high
+    confidence: 0.9
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_body_has_dynamic_exec: true
+    explanation: >
+      This skill's body uses dynamic-context execution (the inline !`cmd` form or
+      a ```! fenced block). Claude Code runs these commands during preprocessing
+      — BEFORE the rendered skill reaches the model — so the model's
+      prompt-injection defenses never see them. Any side effect or data access in
+      the command has already happened by the time Claude could refuse.
+    fix: >
+      Move the work into the skill's instructions so Claude runs it as a normal,
+      model-visible tool call, or into a reviewed bundled script invoked
+      explicitly. Reserve dynamic-context commands for read-only, side-effect-free
+      data — and even then prefer model-visible tool calls.
+
+  - id: CSKILL-003
+    title: Dynamic-context command performs network egress or reads secrets
+    severity: critical
+    confidence: 0.85
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_dynamic_exec_touches_network_or_secrets: true
+    explanation: >
+      A dynamic-context command in this skill performs network egress (curl /
+      wget / nc / …) or reads credentials/secrets (gh auth, $AWS_*, ~/.aws,
+      ~/.ssh, id_rsa, *_key, …). Because these run pre-model during skill load,
+      this is a credential-exfiltration primitive: the secret is read — and can be
+      shipped to an external host — before you or the model can intervene.
+    fix: >
+      Remove the network and credential access from dynamic-context commands
+      entirely. If the skill genuinely needs a secret, have Claude request it as a
+      normal, auditable tool call at runtime — never read it during preprocessing.
+
+  - id: CSKILL-020
+    title: Skill fetches untrusted external content
+    severity: medium
+    confidence: 0.7
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_references_external_url: true
+    explanation: >
+      This skill's body references an external http(s) URL. Content fetched from
+      an external source is an indirect-prompt-injection vector — the fetched text
+      can carry instructions the model then follows — and the URL can double as an
+      exfiltration endpoint. External dependencies can also change after the skill
+      is reviewed.
+    fix: >
+      Avoid fetching external content from a skill. If a reference is required,
+      pin it to a trusted, version-locked source and treat any fetched content as
+      untrusted data, never as instructions.
+
+  - id: CSKILL-040
+    title: Skill body contains prompt-injection markers
+    severity: medium
+    confidence: 0.6
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_body_has_injection_marker: true
+    explanation: >
+      This skill's body carries a prompt-injection signal — instruction-override
+      phrasing ("ignore previous instructions"), zero-width characters used to
+      smuggle hidden text, or a long base64 blob that may conceal instructions.
+      Because the skill description and body enter Claude's context, an injected
+      instruction here can hijack the agent.
+    fix: >
+      Remove the override phrasing, zero-width characters, or encoded blob. A
+      legitimate skill states its guidance in plain, visible text; it never needs
+      to override prior instructions or hide content from review.
+
+  - id: CSKILL-050
+    title: Model-invocable skill grants side-effecting tools
+    severity: high
+    confidence: 0.8
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      all:
+        - skill_model_invocable: true
+        - skill_allows_tool:
+            - Bash
+            - Write
+            - Edit
+            - WebFetch
+            - NotebookEdit
+    explanation: >
+      Claude can auto-invoke this skill (disable-model-invocation is not set) and
+      it pre-approves a side-effecting or exfiltration-capable tool (Bash / Write
+      / Edit / WebFetch / NotebookEdit). The model can therefore be steered — by
+      an ambiguous request or an injected instruction — into triggering the skill
+      and its tools without the user choosing to.
+    fix: >
+      Add `disable-model-invocation: true` so only the user can invoke this skill,
+      or narrow allowed-tools to read-only tools (Read, Grep, Glob). Reserve
+      auto-invocation for skills that carry knowledge, not side effects.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 9
+schema_version: 10


### PR DESCRIPTION
Ships the `claude_skill` rule pack the engine resolves at scan time.

- **CSKILL-001/002/003/020/040/050** (v1 skill-safety): auto-approved shell, pre-model dynamic-context exec + egress/secret exfil, external-content fetch, prompt-injection markers (incl. hidden-Unicode), model-invocable side-effecting skills.
- **CSKILL-010/011** (bundled-script content): network egress + credential reads inside bundled scripts — the payload-in-aux-file surface.
- `schema_version` **9 → 10** for the two new bundled-script predicates; older engines lenient-skip them.

Pairs with the engine PR (discovery + predicates + schema 10) and the rulebook rationale PR — merge together.

Refs: TR-218, TR-219