### PR TITLE
feat(claude_skill): CSKILL-030 hardcoded-secret rule + schema 11

### DIFF
--- a/claude_skill/skill_safety.yaml
+++ b/claude_skill/skill_safety.yaml
@@ -184,3 +184,26 @@ rules:
       legitimately needs a secret, have the user provide it through an explicit,
       auditable runtime prompt — never read it from a bundled script that runs
       automatically when the skill is activated.
+
+  - id: CSKILL-030
+    title: Bundled skill file contains a hardcoded secret
+    severity: high
+    confidence: 0.85
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_bundled_file_has_hardcoded_secret: true
+    explanation: >
+      A file bundled with this skill contains a hardcoded secret — a recognizable
+      credential format such as an AWS access key (AKIA…), a GitHub token
+      (ghp_… / github_pat_…), a Slack or Google API token, an OpenAI-style key, or
+      a private-key block. A committed credential ships to everyone who installs
+      or forks the skill, lives in the repository's history, and is trivially
+      harvested. This is distinct from a script that *reads* a secret at runtime
+      (CSKILL-011): here the secret is the file's own content.
+    fix: >
+      Remove the secret from the bundled file and rotate it immediately — assume
+      it is compromised the moment it is committed. Load credentials at runtime
+      from the environment or a secrets manager, never from a file checked into
+      the skill, and keep real secrets out of version control.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 10
+schema_version: 11


### PR DESCRIPTION
**CSKILL-030** (high) flags a committed secret literal in a bundled skill file — AWS/GitHub/Slack/Google tokens, OpenAI-style keys, private-key headers — distinct from CSKILL-011's runtime credential reads.

`schema_version` **10 → 11** for the new `skill_bundled_file_has_hardcoded_secret` predicate; older engines lenient-skip.

Pairs with the engine PR (discovery + predicate + schema 11) and the rulebook PR — same branch name `feat/skill-hardcoded-secret`.

Refs: TR-265