### PR TITLE
feat(langchain): LC-101 also applies to raw StateGraph (langchain_state_graph)

### DIFF
--- a/langchain/agent_safety.yaml
+++ b/langchain/agent_safety.yaml
@@ -4,7 +4,7 @@ policy:
   category: langchain
   description: >
     Agent-scope safety and reliability rules for LangChain / LangGraph agents
-    (create_react_agent, create_agent, AgentExecutor).
+    (create_react_agent, create_agent, AgentExecutor, and raw StateGraph graphs).
 
 rules:
   - id: LC-101
@@ -15,6 +15,7 @@ rules:
     applies_to:
       - langchain_agent
       - langchain_agent_executor
+      - langchain_state_graph
     scope: agent
     match:
       agent_uses_hosted_tool_class:


### PR DESCRIPTION
Widen the LangChain code-execution / shell agent rule (LC-101) to the raw LangGraph **StateGraph** agent kind by adding `langchain_state_graph` to its `applies_to`.

Companion to engine PR [trustabl/trustabl#65](https://github.com/trustabl/trustabl/pull/65), which adds raw `StateGraph` discovery and resolves a graph's `ToolNode([...])` / `llm.bind_tools([...])` tools into hosted-tool edges. With this rule change, a hand-wired graph wiring a `PythonREPLTool` / `ShellTool` now fires LC-101.

This mirrors the in-engine test fixture exactly, so it clears the engine's `rules-sync` CI check (currently red on PR #65 only because the fixture has this line and production does not yet).

Severity stays `high` (unchanged from current production). Note: a separate unpushed local reclassification of LC-101 to `critical` is intentionally **not** included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
