### PR TITLE
fix(ci): sign in the gated job so it can read the production env secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,12 @@ jobs:
   # No channel re-point happens here.
   build:
     runs-on: ubuntu-latest
+    # The signing key is a `production` ENVIRONMENT secret, and environment secrets
+    # are only readable by a job that declares the environment — so the job that
+    # SIGNS must be the gated one. Declaring it here makes the whole signed publish
+    # wait for the required-reviewer approval before anything is signed or released
+    # (the self-verify still hard-blocks promoting a bad statement).
+    environment: production
     outputs:
       digest: ${{ steps.bundle.outputs.digest }}
     steps:
@@ -185,13 +191,13 @@ jobs:
           path: ${{ runner.temp }}/statement.json
           retention-days: 7
 
-  # Re-point the channel release to the new statement. Gated behind the
-  # `production` environment so it requires manual approval — build/sign/verify
-  # happen above without auto-promoting.
+  # Re-point the channel release to the new statement. The approval gate is on the
+  # `build` job (which holds the signing secret); promote only runs after that
+  # gated, self-verified build succeeds, so the re-point is already behind the
+  # required-reviewer approval and needs no second gate here.
   promote:
     needs: build
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - name: Download statement
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The Sign step ran in the un-gated `build` job, but `RULES_SIGNING_KEY_ED25519` is a **production-environment** secret — env secrets are only readable by a job that declares the environment. So the build job would see an empty secret and the **first publish fails at sign** (`secret not set`).

Fix: move `environment: production` onto the `build` job (the one that signs). The whole signed publish now waits for the required-reviewer approval before anything is signed/released; `promote` runs after the gated, self-verified build, so the channel re-point stays gated without a second approval. Caught while validating the pipeline after the engine merge; the ci-workflow audit lens had been throttled before it could verify this. (TR-323)

🤖 Generated with [Claude Code](https://claude.com/claude-code)