### PR TITLE
chore(publish): label channel/bundle releases as auto-managed pre-releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,8 +144,9 @@ jobs:
             echo "bundle release $tag already exists - skipping (content-addressed)."
           elif gh release create "$tag" "$RUNNER_TEMP/bundle.tar.gz#bundle.tar.gz" \
               -R "${{ github.repository }}" \
-              --title "Rules bundle ${{ steps.bundle.outputs.digest }}" \
-              --notes "Immutable content-addressed rule bundle. Committed by a signed channel statement."; then
+              --title "Rules bundle ${{ steps.bundle.outputs.digest }} (content-addressed)" \
+              --notes "Immutable content-addressed rule bundle. Committed by a signed channel statement. Auto-managed; not a downloadable release." \
+              --prerelease --latest=false; then
             echo "created bundle release $tag."
           elif gh release view "$tag" -R "${{ github.repository }}" >/dev/null 2>&1; then
             # Lost a create race with a concurrent run; content is identical
@@ -218,8 +219,9 @@ jobs:
             # to clobber-upload so the channel ends up pointed at this statement.
             gh release create "$tag" "stmt/statement.json#statement.json" \
               -R "${{ github.repository }}" \
-              --title "Channel: $CHANNEL" \
-              --notes "Signed pointer to the current bundle for the $CHANNEL channel." \
+              --title "Signed rules channel: $CHANNEL (auto-managed)" \
+              --notes "Signed pointer to the current bundle for the $CHANNEL channel. Auto-managed; fetched by the scanner, not a downloadable release." \
+              --prerelease --latest=false \
               || gh release upload "$tag" "stmt/statement.json" --clobber -R "${{ github.repository }}"
           fi
           echo "promoted $CHANNEL -> bundle ${{ needs.build.outputs.digest }}"


### PR DESCRIPTION
## What

Future `publish.yml` runs now create the `channel-<name>` and `bundle-<digest>`
releases with clearer, self-describing titles and as **pre-release / not-latest**,
so they no longer claim the repo's **Latest** badge or read like version releases.

- `channel-<name>` -> title "Signed rules channel: `<name>` (auto-managed)", `--prerelease --latest=false`
- `bundle-<digest>` -> title "Rules bundle `<digest>` (content-addressed)", `--prerelease --latest=false`

## Why

These releases are machine-addressing artifacts the engine fetches by tag, not
human version releases. Before this, the newest channel pointer grabbed the
**Latest** badge (misleading) and the bare "Channel: staging" / "Rules bundle …"
titles looked like real releases. A pre-release can never be "Latest", so the
real semver release (`v0.1.0`) keeps that badge.

## No engine impact

Tags (`channel-<name>`, `bundle-<digest>`) and asset filenames are unchanged, so
nothing the engine resolves changes. Purely the release **title** + the
**latest/prerelease** metadata, which the engine never reads.

The already-published `channel-staging`, `channel-production`, and `bundle-…`
releases were retro-labeled the same way out of band; this just makes every
future publish land consistently.