### PR TITLE
feat: attestation ledger and automate detection rules for attestation

### DIFF
--- a/.github/workflows/attest-rules.yml
+++ b/.github/workflows/attest-rules.yml
@@ -1,0 +1,175 @@
+name: Attest rule pack
+
+# Weekly per-file attestation ledger for the rule packs in this repo. This is
+# NOT the bundle/channel signing in publish.yml (Ed25519, gated production
+# environment, signs the whole resolved bundle for the engine to trust at
+# scan time). This workflow answers a narrower, audit-facing question: "was
+# this individual rule file reviewed/attested, and when." It maintains
+# attestations.json (sha256 + attested_at date + commit per rule file) and
+# signs that ledger keyless via cosign/Sigstore, using this workflow's own
+# ambient GitHub Actions OIDC identity - no signing secret to provision or
+# rotate. See attestations.json for the ledger itself.
+
+on:
+  schedule:
+    # Every Monday, 00:00 UTC. Not tied to pushes: the ledger is a periodic
+    # sweep that diffs live file content against last-recorded hashes, so any
+    # number of rule merges during the week are picked up correctly here.
+    - cron: "0 0 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # push the ledger-update branch
+  pull-requests: write # open the PR
+  id-token: write # ambient OIDC token for keyless cosign signing
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+concurrency:
+  group: attest-rules
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    # Keyless signing binds the signer identity to this workflow file at
+    # refs/heads/main on THIS repo. A fork running the same schedule would
+    # sign with a different (unpinnable) identity, so skip there.
+    if: github.repository == 'trustabl/trustabl-rules'
+    steps:
+      - name: Checkout rules
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: sigstore/cosign-installer@v3
+
+      # Walk every rule yaml (all except manifest.yaml, which is pack
+      # metadata, not a policy - see CLAUDE.md), hash it, and diff against
+      # the ledger. A file's attested_at only moves when its content
+      # (sha256) actually changes or it's new - unchanged files keep their
+      # original attestation date, so the ledger stays an honest history
+      # instead of a rubber stamp that refreshes every run.
+      - name: Update attestation ledger
+        id: ledger
+        run: |
+          python3 - <<'PYEOF'
+          import hashlib
+          import json
+          import os
+          import subprocess
+          import datetime
+
+          head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+          today = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+          files = sorted(
+              f
+              for f in subprocess.check_output(["git", "ls-files", "*.yaml"], text=True).splitlines()
+              if f != "manifest.yaml"
+          )
+
+          ledger_path = "attestations.json"
+          try:
+              with open(ledger_path) as fh:
+                  ledger = json.load(fh)
+          except FileNotFoundError:
+              ledger = {"rules": {}}
+
+          rules = ledger.setdefault("rules", {})
+          changed = False
+
+          seen = set()
+          for f in files:
+              seen.add(f)
+              with open(f, "rb") as fh:
+                  digest = hashlib.sha256(fh.read()).hexdigest()
+              existing = rules.get(f)
+              if existing is None or existing.get("sha256") != digest:
+                  rules[f] = {
+                      "sha256": digest,
+                      "attested_at": today,
+                      "attested_commit": head,
+                  }
+                  changed = True
+
+          removed = [f for f in rules if f not in seen]
+          for f in removed:
+              del rules[f]
+              changed = True
+
+          if changed:
+              with open(ledger_path, "w", newline="\n") as fh:
+                  json.dump(ledger, fh, indent=2, sort_keys=False)
+                  fh.write("\n")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"changed={'true' if changed else 'false'}\n")
+
+          print(f"rule files: {len(files)}, removed: {len(removed)}, changed={changed}")
+          PYEOF
+
+      # Keyless: no signing secret. cosign auto-detects the ambient GitHub
+      # Actions OIDC token (available because of the id-token: write
+      # permission above), exchanges it with Fulcio for a short-lived signing
+      # cert, and signs - non-interactively, no browser/login prompt (that
+      # flow only happens when running cosign keyless from a local machine).
+      # Uploads to the public Rekor transparency log by default, which is a
+      # feature here: a public, third-party-timestamped record of "Trustabl
+      # attested these rule files on this date" - not a leak, since this is
+      # already a public repo.
+      - name: Sign ledger (keyless cosign / Sigstore)
+        if: steps.ledger.outputs.changed == 'true'
+        run: |
+          cosign sign-blob --yes \
+            --output-signature attestations.json.sig \
+            --output-certificate attestations.json.pem \
+            attestations.json
+
+      # Self-verify before opening a PR, so a broken signature fails the
+      # workflow here instead of shipping a PR nobody can trust.
+      - name: Self-verify signature
+        if: steps.ledger.outputs.changed == 'true'
+        run: |
+          cosign verify-blob \
+            --certificate attestations.json.pem \
+            --signature attestations.json.sig \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest-rules.yml@refs/heads/main" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            attestations.json
+
+      - name: Open PR with signed ledger update
+        if: steps.ledger.outputs.changed == 'true'
+        run: |
+          branch="attest-rules-update-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add attestations.json attestations.json.sig attestations.json.pem
+          git commit -m "chore(attestation): update signed rules ledger"
+          git push origin "$branch"
+          gh pr create \
+            --base main --head "$branch" \
+            --title "chore(attestation): update signed rules ledger" \
+            --body "$(cat <<'EOF'
+          Auto-generated by `attest-rules.yml`.
+
+          Updates `attestations.json` with the rule files that are new or
+          changed since the last attestation, and re-signs it keyless via
+          cosign/Sigstore using this workflow's ambient GitHub Actions OIDC
+          identity (logged to the public Rekor transparency log).
+
+          Verify independently before merging:
+
+          ```
+          cosign verify-blob \
+            --certificate attestations.json.pem \
+            --signature attestations.json.sig \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attest-rules.yml@refs/heads/main" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            attestations.json
+          ```
+          EOF
+          )" \
+            --label automated

--- a/attestations.json
+++ b/attestations.json
@@ -1,0 +1,424 @@
+{
+  "rules": {
+    "autogen/agent_safety.yaml": {
+      "sha256": "76917870dd26541fd388b59e917efbcb1e6c6d47ac34d2611fe1b8ff78d897d3",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "autogen/code_execution.yaml": {
+      "sha256": "7aebc61dd9114d763d660e5c67f0a2ebf9d9f13421b3371fc888e1bb9f31065b",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "autogen/network.yaml": {
+      "sha256": "6ddb896f8714dec04677f60a8fbeab80ae5fd9518b88d7a0af53914cc42b2248",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "autogen/repo_hygiene.yaml": {
+      "sha256": "d7c15faaf8bca00604faa283327a8a863e723a2681945ec06ece6a180064144c",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "autogen/shell_safety.yaml": {
+      "sha256": "c585c165cec94110023a5c203859a42a1d082499fe0beb82de6bf0999f823dc5",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "autogen/ssrf.yaml": {
+      "sha256": "1e493540b5cce2db66e0797bc148333aea205762ccac46163415d839fffaecea",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "autogen/tool_definition.yaml": {
+      "sha256": "6e81e50bbd492cd68cf58cf5e7dafeb3f52af7eddbff1ff1a2f5cacd3907963b",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/agent_safety.yaml": {
+      "sha256": "7b700ebbe830f83054fb82d4753f96553169b22af732bd4e530188e6f49dda7d",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/code_execution.yaml": {
+      "sha256": "cb21054e89561859b95631c47dd804f3a4542928ca0b4cdf1e208d4a0e493c08",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/error_handling.yaml": {
+      "sha256": "e6729f824852468548d37b3a125e2b9f3c1b63fdfb7a2cb27b5bf2dd5aa4fe17",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/idempotency.yaml": {
+      "sha256": "fa7c4dc301594b81d784a1b0b1abd2f48ef3b68dd4792ea3c51fe84493f1147c",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/network.yaml": {
+      "sha256": "5232d2c0145b3d19bba948d3417e06df283a247dc196dc6331f829a77d94870f",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/path_safety.yaml": {
+      "sha256": "f474e561cf2d3abd69163894ffef93e5fc86f9f03e539a6548a06c7f3611b668",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/repo.yaml": {
+      "sha256": "80705b5748c4f99b4a819a590eca8d567c1bf70c7bf60bb83d6b8e5e14dfe6ab",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/repo_hygiene.yaml": {
+      "sha256": "15e690f29a8b5ca5a3566476a009fbc14e58a9a52866e1e71b62404dfeab3a67",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/shell_safety.yaml": {
+      "sha256": "c60b9593d6c7e48fc65560b820e327fff9330a9952c231cc309edea873f051e1",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/ssrf.yaml": {
+      "sha256": "cba6d419ce42e2534fc0340fdc45f45b93aa8946fa96d5ab8e8bc148f4433737",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/subagent_safety.yaml": {
+      "sha256": "e9d9a140c72f61d63577898435dc5f84c2b4b04ec9cf766d5ea04c7cbfbe31ae",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_sdk/tool_definition.yaml": {
+      "sha256": "148869dd81257a2b789ff7e989dc057338805620dd810bc7edefc30680306e83",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "claude_skill/skill_safety.yaml": {
+      "sha256": "75183e4567e033692f14b84ba929161f20c65735ae2668ef53f48e9548324ef7",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/agent_safety.yaml": {
+      "sha256": "a5defc94b02a3d24fc84b6170de024b9a2b2a30b4e51d6e749f98aef36e9ede7",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/code_execution.yaml": {
+      "sha256": "1728249e6ceab915dd63fc2db43263c6cd430de0ca4b49bfd6e0a8799f93ee69",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/dangerous_tools.yaml": {
+      "sha256": "0457034c3ae663e23cfdb26575645ef82d2a51e611356f90d654a03df353df41",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/idempotency.yaml": {
+      "sha256": "3cad9fcf7d7012d826f8c021fc773aeceabb8949cba3997ba9eada6c698f27e6",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/repo_hygiene.yaml": {
+      "sha256": "7624b509d99f653e6d4022e180ffc9bd7b8ba4d5271a490df94fd5ea3e411030",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/shell_safety.yaml": {
+      "sha256": "16514477d511dff1a7fc9a8e72d5c78cf318b91b4b4d18ae90152a899a53729f",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/ssrf.yaml": {
+      "sha256": "3e6005f40e984833e18ad7a9032b0fc93698d78bb240a4d486d65def2499ce07",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/tool_behavior.yaml": {
+      "sha256": "f80b619613e3251f63469eb2454b18469cefab7d2c68ac3865b1298c03a40f15",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "crewai/tool_definition.yaml": {
+      "sha256": "21998857f4dbe6e70825b72c0608e604c3994060525f549f801f552177700dc7",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/agent_safety.yaml": {
+      "sha256": "c8928e5c6f3065fa0feb80fcf3c3d55ae102253c838ee6f3846288efd8a9a7cd",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/builtin_tools.yaml": {
+      "sha256": "b80e468ecde32fc00f938e2b58b0d599baa78a67997833cfdcb86aca7021f9a6",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/code_execution.yaml": {
+      "sha256": "874fe5199f89ead803b35ac087a4ad6a7d971dd6b1e624ae35306c8693758624",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/error_handling.yaml": {
+      "sha256": "4efa05633fbc47e16e93a7c6433a0b68038e50ffc81546f7e1205f75bf8519db",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/idempotency.yaml": {
+      "sha256": "a85c19c2045bb9488054fc347f273f7f504cdc833f001ffbe734849d0fcda72e",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/network.yaml": {
+      "sha256": "f9553381a9791f07e099924d97da0306e5c6da7dff56b2a08767d61b7beb71d3",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/path_safety.yaml": {
+      "sha256": "ec4de99e7e747c13142e02309821bd11e7b8a28b77e89e7062250021c118b6c3",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/repo_hygiene.yaml": {
+      "sha256": "78c7bddd9e551383e3d31a05f9d7cf565360a1d63429a538e741e0c3bed27f23",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/shell_safety.yaml": {
+      "sha256": "97fcb1a2f587c805f4f9077838df9b393f5355cf047d91eaa41d1573cf3ac6e3",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/ssrf.yaml": {
+      "sha256": "ebbe40fc19274c0ee543d31f0d23f355cf2d09eba33b7afa818642b549045c49",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "google_adk/tool_definition.yaml": {
+      "sha256": "382ab9b5c5cce6aa50a11833724206cf8bc32e519f28e240dcd21021fb4d525b",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "langchain/agent_safety.yaml": {
+      "sha256": "577e1f8feeca816e063ac65fc3ec2a164f38987c11244a34f7b25622ae05e501",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "langchain/code_execution.yaml": {
+      "sha256": "40f12c9d9927a2b90d1529bbafbff21edd4ae477718c03b00dbbb46af4cf23cd",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "langchain/repo_hygiene.yaml": {
+      "sha256": "34b61904345dc345656e02fa4244e2954ee2a58aac1ed3ae0065197434637ab3",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "langchain/shell_safety.yaml": {
+      "sha256": "ad4c8ebbe25052aeeb125f1f5127f88c5aedeaee4527fc501705a66c6547d944",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "langchain/ssrf.yaml": {
+      "sha256": "4fbfd26977495eef390a66e63da90836994d31d974d9be8ab7dafa11a9daa45b",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "langchain/tool_behavior.yaml": {
+      "sha256": "b7c80d94c01044b49026749fb7f07f329f86eb0a91892c5e187c12107e3f439d",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "langchain/tool_definition.yaml": {
+      "sha256": "978c2e157cf6cdbd6171f19a1c1ac790e8109da1733e79988dff9e9dda5a3a15",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/code_execution.yaml": {
+      "sha256": "79391bfb11bd0213b80d9afa028512f15d04c67831d4f0e3db80ce446b5c705a",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/error_handling.yaml": {
+      "sha256": "5fb14d8fd98c7637224fe07b4943094682b942c3356a9cdf2be1c285ab42f777",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/idempotency.yaml": {
+      "sha256": "eb9f4672465959c41b2829ae808b119a10d30fd1383f1fd58c3a1dd059aab32b",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/network.yaml": {
+      "sha256": "2db0cbce3244a2a14eee7d14e8b9769e3f1c5c3827908056d9d765f01e0d4fe7",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/path_safety.yaml": {
+      "sha256": "9200eee9ee6844daf747b00e9ce183881590d717fc34cfd03b3bde3672f7f39d",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/shell_safety.yaml": {
+      "sha256": "c0e1ee4ef38402aa650ad23d7660377edb41827b64a40a5b427a15253f0c1c48",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/ssrf.yaml": {
+      "sha256": "254edb23c78bf6ce114581af6c9076dcc7bff378649adfe8123a48f45af05121",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "mcp/tool_definition.yaml": {
+      "sha256": "4155f4e514c5d373ff34038650d54a5e984bb612ecf3bd1eaad3abbe23fd2e6a",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/agent_safety.yaml": {
+      "sha256": "b8b630fe2f44e64fcab2986140284410ff201bb73ac47fcb5d617f4149a73df4",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/approvals.yaml": {
+      "sha256": "26bda535e89429d77d8775b75ca42b87079185066b4418908647eb18832a714f",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/code_execution.yaml": {
+      "sha256": "a4354cb83608b75f2652429c68067451a862c1bf99bf7926852a36bc63166020",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/decorator_config.yaml": {
+      "sha256": "3bd7611a3f22bb97467011158e867494b604e512bbecc77e0bf2fe8a97fcb2ee",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/error_handling.yaml": {
+      "sha256": "dab77a97c91518b3fed054a1877f75c476e6a38faade760b3fddaf2feabbbd9d",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/idempotency.yaml": {
+      "sha256": "e242a46b528aabf06103d77a7e0a1d2c144e7ee2db33fd41907cd470f465b196",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/mcp_safety.yaml": {
+      "sha256": "95ad30b59aa24d08d339b8444ce1108574048800d14ece89d471c3fa521b4729",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/network.yaml": {
+      "sha256": "f4d416da78b3a172749703d0f30a8261c737d06bbaecc1da869a8a54b3624fc6",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/observability.yaml": {
+      "sha256": "f77d261f0626541ce10bf7af8d8ada4e4eaf89d8ec43e242ac29491fde5b74ab",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/path_safety.yaml": {
+      "sha256": "c4c49a91f7a3338f25d0edcb6d4987806c2fc22fa94c132b5c4975ee8859979c",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/repo_hygiene.yaml": {
+      "sha256": "4de027b5c048e0524c2f55fd18c9aa91cf4b5afc7b8463782542769473ef428e",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/shell_safety.yaml": {
+      "sha256": "49c5deff382d374a46a6044f1c85716d5bb4189afc4a715c019f65afd75d47db",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/tool_definition.yaml": {
+      "sha256": "4eb945b41f061db3c69f0910a7203d8042c8b8303a256385605c54af7c2d5d5b",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "openai_sdk/tracing.yaml": {
+      "sha256": "89ed43a6f26f0200cfd6a5ade3f7f685a1f3ec182c1a1aa5c91a156fde8bd991",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/agent_safety.yaml": {
+      "sha256": "6c02f09c74b57e18951177a27837111b1406f8249319157197e7d63c9346058b",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/code_execution.yaml": {
+      "sha256": "64a2a7890214d160fff55f66e5ee588a07a63c99fe1f117809389488a242b73e",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/idempotency.yaml": {
+      "sha256": "aab71bd1c037ed0958ea990fbcf2328a342ef4b9371b4eba66186990e4094948",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/network.yaml": {
+      "sha256": "7ec8a937854136d8b7d5b5ee0641c652d3b814298ad65ac5055c5d3ef880be12",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/repo_hygiene.yaml": {
+      "sha256": "cfe7cf8600b592c892f9074fc27b85b32ffad2acbd4caa8944eebcb628d8c622",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/shell_safety.yaml": {
+      "sha256": "4d1b98a36979f06e26e70f5b39ea4514a738c3b35fb38ceaae7712b93ca12f98",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/ssrf.yaml": {
+      "sha256": "7289fb1459905841e476ce0abbe38ee07a29c0c4d9bf1e0ee89530c182fe8bc8",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "pydantic_ai/tool_definition.yaml": {
+      "sha256": "715f9d9c1132f25b9223aa46b974e95ae45f982db957857dd82cd0a53c046c83",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "vercel_ai/agent_safety.yaml": {
+      "sha256": "b986668c11e1d557290c86f16ffc6a85ba2da3e0b3b581727763bd27599e29fd",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "vercel_ai/code_execution.yaml": {
+      "sha256": "6098a90f3596d9c0b295a29b2e5cb293c5c5923b2993b5ef265265a3a3323a86",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "vercel_ai/network.yaml": {
+      "sha256": "495e64f6dd466cb4143d9a40b3d6c6f59ce5c19d7c12c0372dbe1c2d8b87ca62",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "vercel_ai/repo_hygiene.yaml": {
+      "sha256": "b161de62063acc6442109182101bf0000a6e6c275d7ac3d93494a2b80921313d",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "vercel_ai/shell_safety.yaml": {
+      "sha256": "bb66056d664b388fe4c1e4b38256e04acf5382c8fc5ff46fdcc6f8547aea7234",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "vercel_ai/ssrf.yaml": {
+      "sha256": "7ba3fa36f590e60f00f45514118f4b8774142c66cfa130d0c8177645992e88a1",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    },
+    "vercel_ai/tool_definition.yaml": {
+      "sha256": "67620139c16190562754a3c7856aea1810a5c1ec6ce3365f7017d9a698476da5",
+      "attested_at": "2026-07-21",
+      "attested_commit": "97918c43909166334a2df941cff64d9f63acb115"
+    }
+  }
+}


### PR DESCRIPTION
# Add weekly rule-pack attestation ledger (keyless cosign/Sigstore)

## How this works

1. Runs every Monday 00:00 UTC (or manually via `workflow_dispatch`).
2. Checks every rule file's hash against the ledger to find new or changed
   rules — everything else is left untouched.
3. Attests each new/changed rule: records its hash + today's date + commit,
   then signs the whole ledger keyless via cosign/Sigstore.
4. Opens a PR, authored by `github-actions[bot]`, with the signed ledger
   update for the newly attested rules — a human merges it.
   
## What is this?

A per-file record of "was this rule reviewed, and when" — separate from
`publish.yml`, which signs the whole bundle for the engine to trust at scan
time. This ledger exists to justify individual rules as something Trustabl
stands behind, on request.

- **`attestations.json`** — one entry per rule file: content hash, the date
  it was last attested, and the commit that attested it. Seeded now for all
  84 existing rule files.
- **`.github/workflows/attest-rules.yml`** — runs every Monday 00:00 UTC
  (plus manual dispatch). Diffs live file hashes against the ledger, updates
  only what changed, signs the ledger keyless via cosign/Sigstore, and opens
  a follow-up PR with the signed result.

> **Keyless** means no stored signing secret. Cosign uses this workflow's own
> ambient GitHub Actions OIDC identity — the certificate proves *which
> workflow* signed, not a person — and (by default) logs to the public Rekor
> transparency log.

## Files changed

| File | |
| --- | --- |
| `attestations.json` | new |
| `.github/workflows/attest-rules.yml` | new |

## Not signed yet

This PR only seeds the ledger — it carries no `.sig` / `.pem`. Those first
appear in the bot's follow-up PR, after the first scheduled (or manually
dispatched) run of `attest-rules.yml` once this merges.

## How to use it later

Is rule `claude_sdk/network.yaml` attested, and when?

```bash
jq '.rules["claude_sdk/network.yaml"]' attestations.json
# → { "sha256": "…", "attested_at": "2026-07-21", "attested_commit": "97918c4…" }
```

Once a signed ledger PR lands, verify it independently:

```bash
cosign verify-blob \
  --certificate attestations.json.pem \
  --signature attestations.json.sig \
  --certificate-identity "https://github.com/trustabl/trustabl-rules/.github/workflows/attest-rules.yml@refs/heads/main" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  attestations.json
```