### PR TITLE
feat(claude_sdk): add CSDK-204, session sets no explicit max_turns limit

### DIFF
--- a/claude_sdk/repo.yaml
+++ b/claude_sdk/repo.yaml
@@ -57,3 +57,30 @@ rules:
       auto-approve only file edits while still gating shell and network access).
       Reserve bypassPermissions for disposable sandboxes, never code that runs
       on a developer's or user's machine.
+
+  - id: CSDK-204
+    title: Claude Agent SDK session sets no explicit max_turns limit
+    severity: low
+    confidence: 0.6
+    applies_to:
+      - claude_sdk
+    scope: repo
+    match:
+      repo_claude_options_max_turns_missing: true
+    explanation: >
+      No ClaudeAgentOptions(...) in this project sets max_turns, so the agent
+      loop runs to whatever ceiling the runtime applies by default rather than
+      to a bound sized for this task. A model that loops or oscillates —
+      retrying a failing tool, re-reading the same file, ping-ponging between
+      two steps — keeps consuming turns, tokens, and tool side effects until
+      that implicit ceiling is reached, and an implicit ceiling can shift
+      between SDK versions without any change on your side. An explicit cap
+      also turns a stuck run into a clean, observable stop instead of a slow
+      burn.
+    fix: >
+      Pass max_turns= to ClaudeAgentOptions(...), sized to the work the
+      session actually does — a handful of turns for a single-file edit, more
+      for a multi-step investigation. Treat hitting the cap as a signal to
+      surface and handle rather than to raise it: if a task legitimately
+      needs many turns, split it into bounded sub-sessions instead of
+      removing the bound.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 13
+schema_version: 14


### PR DESCRIPTION
Mirrors the engine fixture change byte-for-byte. Closes execution-limit coverage gap for Claude Agent SDK sessions, matching LC-102, VAI-007, ADK-108, AG2-006, and CREW-110.

schema_version bumped 13 -> 14.