### PR TITLE
feat(rules): add OAI-112, PYD-106 execution-limit rules

### DIFF
--- a/openai_sdk/agent_safety.yaml
+++ b/openai_sdk/agent_safety.yaml
@@ -165,6 +165,35 @@ rules:
       on the Agent(...) constructor. It should inspect the final output for
       data exfiltration and unsafe content before it is returned.
 
+  - id: OAI-112
+    title: OpenAI Agents SDK agent has no explicit max_turns limit
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - openai_agent
+      - openai_sandbox_agent
+    scope: agent
+    match:
+      agent_run_call_max_turns_missing: true
+    explanation: >
+      No Runner.run/run_sync/run_streamed call that executes this agent sets
+      max_turns, so the loop runs to whatever ceiling the SDK's
+      DEFAULT_MAX_TURNS applies rather than to a bound sized for this task. A
+      model that loops or oscillates — retrying a failing tool, re-reading the
+      same file, ping-ponging between two steps — keeps consuming turns,
+      tokens, and tool side effects until that implicit ceiling is reached,
+      and an implicit ceiling can shift between SDK versions without any
+      change on your side. An explicit cap also turns a stuck run into a
+      clean, observable MaxTurnsExceeded instead of a slow burn.
+    fix: >
+      Pass max_turns= to Runner.run(...) (or run_sync/run_streamed), sized to
+      the work this agent actually does — a handful of turns for a
+      single-lookup agent, more for a multi-step task. Treat hitting the cap
+      as a signal to surface and handle rather than to raise it: if a task
+      legitimately needs many turns, split it into bounded sub-runs instead of
+      removing the bound.
+
   - id: OAI-105
     title: TypeScript agent wires a content-fetching hosted tool without inputGuardrails
     severity: high

--- a/pydantic_ai/agent_safety.yaml
+++ b/pydantic_ai/agent_safety.yaml
@@ -124,3 +124,30 @@ rules:
       model produces a final result, skipping pending tool calls. Only choose
       exhaustive when every tool the agent can call is side-effect-free and you
       specifically need the remaining calls to complete.
+
+  - id: PYD-106
+    title: Pydantic AI agent has no explicit usage_limits set
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_run_call_usage_limits_missing: true
+    explanation: >
+      No run/run_sync/run_stream call that executes this agent sets
+      usage_limits, so Pydantic AI falls back to a bare UsageLimits() —
+      capping request count but leaving token and cost usage completely
+      unbounded. A model that loops or oscillates, or a single run that
+      balloons into an unexpectedly long tool-calling chain, can burn far more
+      tokens and cost than the task warrants before the request cap is ever
+      reached, and nothing stops a single expensive run from running the bill
+      up. An explicit, task-sized UsageLimits also turns a runaway run into a
+      clean UsageLimitExceeded instead of a silent cost overrun.
+    fix: >
+      Pass usage_limits=UsageLimits(...) to agent.run/run_sync/run_stream,
+      sized to the task — request_limit for a hard step count, and
+      total_tokens_limit or input_tokens_limit/output_tokens_limit to bound
+      token spend directly. Treat hitting the limit as a signal to surface and
+      handle rather than to raise it.


### PR DESCRIPTION
Closes the execution-limit coverage gap for OpenAI Agents SDK and Pydantic AI, using the new agent_run_call_max_turns_missing and agent_run_call_usage_limits_missing predicates (merged in the trustabl engine, feat/openai-pydantic-execution-limit-discovery).

- OAI-112: agent has no explicit max_turns set at the Runner.run/run_sync/run_streamed call site
- PYD-106: agent has no explicit usage_limits set at the agent.run/run_sync/run_stream call site — Pydantic AI's default UsageLimits() caps request count but leaves token/ cost usage unbounded, the specific risk this rule flags

Both severity low, confidence 0.6, matching the established calibration for this finding class (LC-102, CREW-110, CSDK-204). Default-value claims deliberately hedged where SDK docs and source conflicted, rather than asserting an unverified number.

Mirrored into the engine fixture per the sync obligation. 206 total rules, validated under schema version 14.