### PR TITLE
feat(crewai): add CREW-007, tool network call has no timeout

### DIFF
--- a/crewai/network.yaml
+++ b/crewai/network.yaml
@@ -1,0 +1,57 @@
+policy:
+  id: crewai_network
+  name: CrewAI tool network hygiene
+  category: crewai
+  description: >
+    Network-call hygiene inside CrewAI tool functions. A tool that issues an
+    outbound request with no deadline stalls the agent that called it, and in a
+    crew that agent's task blocks every task sequenced behind it.
+
+rules:
+  - id: CREW-007
+    title: CrewAI tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - requests.Session.get
+          - requests.Session.post
+          - urllib.request.urlopen
+          # Bare `urlopen` covers the from-import form.
+          - urlopen
+          # Aliased aiohttp sessions canonicalize to aiohttp.ClientSession.<m>.
+          - aiohttp.ClientSession.get
+          - aiohttp.ClientSession.post
+        missing: timeout
+    explanation: >
+      This CrewAI tool makes a network request with no timeout, so it hangs
+      indefinitely on a slow or unresponsive remote. The cost is worse than one
+      stuck agent: a crew executes tasks in sequence and passes each task's
+      output forward as context, so a tool stalled inside one task blocks every
+      task behind it and the whole crew produces nothing. CREW-110's max_iter cap
+      bounds how many reasoning steps an agent takes, not how long a single tool
+      call may run, so it never breaks the stall.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough for this endpoint's legitimate slow
+      responses, and catch the resulting timeout so the tool returns a structured
+      error string the agent can reason about instead of leaving the crew hung.


### PR DESCRIPTION
CrewAI had no network-timeout rule, unlike Pydantic AI (PYD-006), AutoGen (AG2-012), and the Vercel AI SDK (VAI-011).

The blast radius is larger here than in a single-agent SDK. A crew runs tasks in sequence and threads each task's output forward as context, so a tool stalled inside one task blocks every task behind it and the crew produces nothing. CREW-110's `max_iter` doesn't help — it bounds how many reasoning steps an agent takes, not how long a single tool call may run.

Same `call_without_kwarg` callee list as PYD-006, so the alias-aware `requests.Session` / `aiohttp.ClientSession` handling matches the shipped rules.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`requests.get(url)`): `CREW-005, CREW-007, CREW-201`
Silent (`requests.get(url, timeout=10)`): `CREW-005, CREW-201`

No new predicates, so no `schema_version` bump.