### PR TITLE
feat(langchain): add LC-008, tool raises without a structured error contract

### DIFF
--- a/langchain/error_handling.yaml
+++ b/langchain/error_handling.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: langchain_error_handling
+  name: LangChain error contract hygiene
+  category: langchain
+  description: >
+    Rules covering how a LangChain tool surfaces failure. By default an
+    exception raised inside a tool escapes the AgentExecutor and ends the run,
+    so the model never sees the failure and never gets a chance to recover from
+    it.
+
+rules:
+  - id: LC-008
+    title: LangChain tool raises without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      This tool raises an exception it never catches. LangChain does not feed
+      tool exceptions back to the model unless you opt in: with the default
+      handle_tool_error=False the exception propagates out of the AgentExecutor
+      and aborts the run, so the model is never told the step failed and the
+      caller gets a traceback instead of an answer. Opting in with
+      handle_tool_error=True is barely better — the model receives the raw
+      str(exception), an opaque sentence with no failure mode, no indication
+      whether a retry could succeed, and whatever internal detail the message
+      happened to carry (file paths, hostnames, query fragments).
+    fix: >
+      Catch the failure modes you expect and return a structured result the
+      model can branch on — an error field naming the failure and a retryable
+      flag — instead of letting the exception escape. Where you do want
+      LangChain to intercept, set handle_tool_error to a callable that maps the
+      exception to a specific, model-readable message rather than to True.


### PR DESCRIPTION
LangChain had no error-contract rule. Claude SDK (CSDK-005), OpenAI (OAI-008), ADK (ADK-005), and MCP (MCP-006) all ship one.

The framing is LangChain-specific. With the default `handle_tool_error=False`, a tool exception propagates out of the `AgentExecutor` and aborts the run — the model is never told the step failed, and the caller gets a traceback instead of an answer. Opting in with `handle_tool_error=True` is only marginally better: the model receives the raw `str(exception)`, with no failure mode, no retryability signal, and whatever internal detail the message happened to carry. The fix text points at `handle_tool_error` as a callable rather than `True`, which is the actual remediation.

**Python only, deliberately.** I drafted a LangChain.js counterpart and dropped it after testing: `PredHasRaise` matches the Python grammar node `raise_statement`, so `has_raise` is structurally always false for a TypeScript tool (whose throws parse as `throw_statement`). The rule validated cleanly but never fired on a fixture that throws. That's an engine-side gap worth closing — `PredHasShellCall` already branches on `models.IsTSOrJS` and reads a discovery-computed fact, so `PredHasRaise` could do the same — but it needs to land in the engine before a TS error-contract rule in this pack (or any other) is worth shipping. Happy to open that PR if useful.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`raise ValueError`, no try/except): `LC-008, LC-201`
Silent (try/except returning a structured error): `LC-201`

No new predicates, so no `schema_version` bump.