### PR TITLE
feat(autogen): add AG2-013, tool raises without a structured error contract

### DIFF
--- a/autogen/error_handling.yaml
+++ b/autogen/error_handling.yaml
@@ -1,0 +1,41 @@
+policy:
+  id: autogen_error_handling
+  name: AutoGen error contract hygiene
+  category: autogen
+  description: >
+    Rules covering how a registered AutoGen tool surfaces failure. An
+    unhandled exception in a tool breaks the two-agent reply loop the whole
+    conversation is built on, so the failure surfaces as a stalled or aborted
+    chat rather than something either agent can reason about.
+
+rules:
+  - id: AG2-013
+    title: AutoGen tool raises without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      This registered tool raises an exception it never catches. AutoGen
+      executes tools on the executor agent's side of the conversation and sends
+      the result back as that agent's reply, so an uncaught exception either
+      aborts initiate_chat outright or comes back as a stringified traceback
+      posted into the message history. In the second case both agents keep
+      talking with a traceback as the last observation: the assistant has no
+      failure mode to branch on and no signal about whether a retry could
+      succeed, so it re-issues the same call until the max_round or auto-reply
+      cap (AG2-004, AG2-006) ends the conversation. The traceback also stays in
+      the transcript, carrying file paths and internal detail into every
+      subsequent turn's context.
+    fix: >
+      Catch the failure modes you expect and return a structured value the
+      assistant can branch on — name the failure and say whether retrying could
+      help and what would need to change — instead of letting the exception
+      escape the registered function. Reserve raising for programmer errors no
+      amount of agent reasoning can work around.


### PR DESCRIPTION
AutoGen had no error-contract rule. Claude SDK (CSDK-005), OpenAI (OAI-008), ADK (ADK-005), and MCP (MCP-006) all ship one.

Framed for AutoGen's two-agent reply loop rather than copied from CSDK-005. Tools execute on the executor agent's side and the result is sent back as that agent's reply, so an uncaught exception either aborts `initiate_chat` outright or lands in the message history as a stringified traceback. The second case is the quiet one: both agents keep conversing with a traceback as the last observation, the assistant has no failure mode to branch on, and it re-issues the same call until AG2-004's `max_round` or AG2-006's auto-reply cap ends the chat. The traceback also stays in the transcript, carrying file paths into every subsequent turn's context.

Used AG2-013 rather than the free AG2-003 — that slot looks retired and IDs are external identifiers, so reuse seemed like the wrong call. Happy to renumber if you'd prefer the gap filled.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`raise ValueError`, no try/except, registered via `register_for_llm`/`register_for_execution`): `AG2-013, AG2-201`
Silent (try/except returning an actionable error string): `AG2-201`

No new predicates, so no `schema_version` bump.