### PR TITLE
feat(pydantic_ai): add PYD-009, path parameter used in I/O without validation

### DIFF
--- a/pydantic_ai/path_safety.yaml
+++ b/pydantic_ai/path_safety.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: pydantic_ai_path_safety
+  name: Pydantic AI filesystem path safety
+  category: pydantic_ai
+  description: >
+    Rules that catch a model-supplied filesystem path flowing into an I/O call
+    inside a Pydantic AI tool without containment. A traversal payload like
+    ../../etc/passwd reaches real filesystem state if the tool does not resolve
+    the path and check it against an allowed root.
+
+rules:
+  - id: PYD-009
+    title: Pydantic AI tool uses a path parameter in I/O without validation
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one. A
+    # body-wide check would suppress the finding whenever any normalization
+    # appears, masking real exposure on the other param.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      This tool takes a path-like parameter and hands it to a file or directory
+      operation without resolving it or checking it against an allowed root, so
+      a model-supplied ../../etc/passwd reaches the real filesystem. Pydantic
+      AI's type layer does not help here: a parameter annotated str or Path
+      validates fine while still carrying a traversal payload, because the
+      annotation constrains the value's type, not the region of the filesystem
+      it points at. Whatever the agent process can read or write, the model can
+      reach through this tool. Detection is heuristic — confirm the parameter is
+      genuinely model-supplied before applying the fix.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert the result sits under
+      an allowed root before touching it, rejecting anything that escapes.
+      Encode that as a validator on the parameter's type (a Pydantic
+      AfterValidator or a custom path type) so containment holds for every tool
+      that accepts it rather than being re-implemented per call site.


### PR DESCRIPTION
Pydantic AI had no path-safety rule. Claude SDK (CSDK-004), OpenAI (OAI-006), ADK (ADK-004), and MCP (MCP-005) all ship one.

The SDK-specific point — and the reason this isn't just CSDK-004 with the names swapped — is that Pydantic AI's type layer looks like it covers this and doesn't. A parameter annotated `str` or `Path` validates cleanly while still carrying `../../etc/passwd`, because the annotation constrains the value's *type*, not the region of the filesystem it points at. The fix text therefore pushes containment into the parameter's type (an `AfterValidator` or a custom path type) so it holds for every tool that accepts it, rather than being re-implemented at each call site.

Uses the per-param `call_uses_unnormalized_path_param` with the same callee set as CSDK-004, so a tool with two path params and one `.resolve()` still fires on the unresolved one.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`open(note_path)` on a raw param): `PYD-009, PYD-101, PYD-201`
Silent (`Path(note_path).resolve()` + `is_relative_to` root check): `PYD-101, PYD-201`

No new predicates, so no `schema_version` bump.