### PR TITLE
feat(langchain): add LC-017, mutating tool has no idempotency key

### DIFF
--- a/langchain/idempotency.yaml
+++ b/langchain/idempotency.yaml
@@ -1,0 +1,53 @@
+policy:
+  id: langchain_idempotency
+  name: LangChain mutating-tool idempotency
+  category: langchain
+  description: >
+    Rules that flag mutating LangChain tools (create/send/refund/...) with no
+    idempotency key. A ReAct agent re-calls a tool whenever an observation reads
+    as inconclusive, so a mutation with no key can commit twice.
+
+rules:
+  - id: LC-017
+    title: Mutating LangChain tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      The tool name signals a side effect (create/send/refund/…) and the tool
+      takes no idempotency key, so a repeated call commits the mutation twice.
+      The LangChain agent loop makes repetition routine rather than
+      exceptional: an AgentExecutor step whose observation reads as
+      inconclusive — a timeout, a truncated response, an error string returned
+      under handle_tool_error — leads the model to reason about the same goal
+      again and re-issue the same action, and it cannot know the first call
+      already committed. Retry wrappers and LangChain's own with_retry compound
+      it, since a network failure after the side effect landed is
+      indistinguishable from one before. The result is a duplicate charge,
+      order, or message.
+    fix: >
+      Accept an idempotency key parameter (idempotency_key / request_id),
+      require the caller to derive it from the unit of work rather than
+      generating a fresh one per call, and de-duplicate server-side so a
+      repeated call returns the first result instead of committing again.


### PR DESCRIPTION
LangChain had no idempotency rule. CrewAI (CREW-006), Pydantic AI (PYD-007), MCP (MCP-007), Claude SDK (CSDK-006), and OpenAI (OAI-009) all ship one.

The LangChain-specific argument is that **repetition is routine here, not exceptional.** An `AgentExecutor` step whose observation reads as inconclusive — a timeout, a truncated response, an error string returned under `handle_tool_error` — leads the model to re-reason about the same goal and re-issue the same action, and it has no way to know the first call already committed. `with_retry` and external retry wrappers compound it: a network failure *after* the side effect landed is indistinguishable from one before.

The fix text adds a point the other packs' rules leave implicit — the key has to be derived from the unit of work, not generated fresh per call, or it de-duplicates nothing.

Same `name_has_prefix` + `param_name_matches` shape as MCP-007, so the detection behavior is consistent across packs.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`refund_payment(charge_id, amount_cents)`): `LC-017, LC-201`
Silent (same tool with an `idempotency_key` param): `LC-201`

No new predicates, so no `schema_version` bump.