### PR TITLE
feat(autogen): add AG2-015, mutating tool has no idempotency key

### DIFF
--- a/autogen/idempotency.yaml
+++ b/autogen/idempotency.yaml
@@ -1,0 +1,54 @@
+policy:
+  id: autogen_idempotency
+  name: AutoGen mutating-tool idempotency
+  category: autogen
+  description: >
+    Rules that flag mutating AutoGen tools (create/send/refund/...) with no
+    idempotency key. A two-agent conversation re-proposes an action whenever the
+    previous observation reads as inconclusive, so a mutation with no key can
+    commit once per round.
+
+rules:
+  - id: AG2-015
+    title: Mutating AutoGen tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      The tool name signals a side effect (create/send/refund/…) and the tool
+      takes no idempotency key, so a repeated call commits the mutation twice.
+      AutoGen's conversation loop makes repetition the default failure mode: the
+      assistant proposes the call, the executor runs it and replies with the
+      result, and if that reply reads as inconclusive — a timeout, an error
+      string, a truncated payload — the assistant proposes the same call again on
+      the next round, with no way to know the first one already committed. It
+      keeps doing so until AG2-004's max_round or AG2-006's auto-reply cap stops
+      the chat, which bounds how many duplicates land rather than preventing
+      them. A group chat is worse again: a second agent that reads the same
+      inconclusive transcript can re-propose the action independently.
+    fix: >
+      Accept an idempotency key parameter (idempotency_key / request_id),
+      require the caller to derive it from the unit of work rather than
+      generating a fresh one per call, and de-duplicate server-side so a
+      repeated call returns the first result instead of committing again.


### PR DESCRIPTION
AutoGen had no idempotency rule. CrewAI (CREW-006), Pydantic AI (PYD-007), MCP (MCP-007), Claude SDK (CSDK-006), and OpenAI (OAI-009) all ship one.

AutoGen's conversation loop makes repetition **the default failure mode**, which is a stronger argument than the one the other packs make. The assistant proposes the call, the executor runs it and replies with the result, and if that reply reads as inconclusive — a timeout, an error string, a truncated payload — the assistant proposes the same call again on the next round, with no way to know the first already committed. It keeps doing so until AG2-004's `max_round` or AG2-006's auto-reply cap stops the chat, which **bounds how many duplicates land rather than preventing them**. A group chat is worse: a second agent reading the same inconclusive transcript can re-propose the action independently.

The fix text notes the key must be derived from the unit of work rather than generated per call, or it de-duplicates nothing.

Same `name_has_prefix` + `param_name_matches` shape as MCP-007. AG2-015 continues from AG2-013/014 in the other PRs in this series; AG2-003 is left alone as a retired slot.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`refund_payment(charge_id, amount_cents)` registered via `register_for_llm`/`register_for_execution`): `AG2-015, AG2-201`
Silent (same tool with an `idempotency_key` param): `AG2-201`

No new predicates, so no `schema_version` bump.