### PR TITLE
feat(pydantic_ai): add PYD-010, PYD-011 tool description quality rules

### DIFF
--- a/pydantic_ai/tool_definition.yaml
+++ b/pydantic_ai/tool_definition.yaml
@@ -62,3 +62,62 @@ rules:
       list[str], a Pydantic model, etc.). Pydantic AI propagates these
       annotations into the schema the model sees, so the model emits
       correctly-shaped arguments and validation stops rejecting them.
+
+  - id: PYD-010
+    title: Pydantic AI tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the PYD-001 has-a-description check but carries a
+      placeholder marker instead of real content. Pydantic AI forwards this text
+      to the model verbatim as the tool's selection signal, so a stub like
+      "TODO: describe this tool" is functionally indistinguishable from no
+      description at all and the model still has to guess from the function
+      name. It also costs more here than in most SDKs: Pydantic AI parses the
+      docstring's parameter sections into the argument schema, so a placeholder
+      body strips the per-argument guidance at the same time as the tool-level
+      guidance, and nothing in the pipeline reports the omission.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it, and add the
+      parameter section (Google, NumPy, or Sphinx style) that Pydantic AI reads
+      into the argument schema.
+
+  - id: PYD-011
+    title: Pydantic AI tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. Pydantic AI passes the docstring to the model as its only
+      selection signal, so a stub like "Gets data." leaves scope and
+      preconditions to guesswork, which shows up as mis-selection or missed
+      calls under ambiguous prompts. A docstring this short also has no room for
+      the parameter section Pydantic AI parses into the argument schema, so the
+      arguments reach the model undescribed as well.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and when this tool should be used over the alternatives, and
+      document each parameter in a section Pydantic AI can parse into the
+      argument schema.


### PR DESCRIPTION
Ports the CSDK-017/018 description-quality pair (merged in #40) to Pydantic AI. PYD-001 only checks that a docstring *exists*, so a tool whose docstring reads `"""TODO: describe this tool."""` or `"""Gets data."""` passes today while giving the model no selection signal at all.

The reason this is worth more than a straight port: **the cost is higher in this pack than in the Claude SDK**, and the rule text says so. Pydantic AI doesn't just forward the docstring as the tool description — it also parses the docstring's parameter sections (Google/NumPy/Sphinx) into the argument schema. So a placeholder or one-clause docstring strips the per-argument guidance at the same time as the tool-level guidance, and nothing in the pipeline reports the omission. The fix text asks for the parameter section explicitly rather than just "a longer description".

Both rules go into the existing `pydantic_ai/tool_definition.yaml` alongside PYD-001/002, which is where the file's policy description already scopes them.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 208 rule(s) valid under rule schema version 14
```

Fire (one tool with `"""TODO: describe this tool."""`, one with `"""Gets data."""`): `PYD-010, PYD-011, PYD-101, PYD-201`
Silent (full description with an `Args:` section): `PYD-101, PYD-201`

Note PYD-011 pairs `description_length_lt: 40` with `has_docstring: true` so it doesn't double-report against PYD-001 on an empty docstring, same as CSDK-018.

No new predicates, so no `schema_version` bump.