### PR TITLE
feat(langchain): add LC-008, LC-009, LC-016 error and idempotency rules

### DIFF
--- a/langchain/error_handling.yaml
+++ b/langchain/error_handling.yaml
@@ -1,0 +1,36 @@
+policy:
+  id: langchain_error_handling
+  name: LangChain error contract hygiene
+  category: langchain
+  description: >
+    Rules covering how a LangChain / LangGraph tool surfaces failures back to
+    the model. Raising raw exceptions yields opaque ToolMessage strings that
+    the model cannot branch on intelligently.
+
+rules:
+  - id: LC-008
+    title: LangChain tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      When a LangChain tool raises, AgentExecutor and LangGraph's ToolNode
+      surface the exception to the model as an opaque ToolMessage (or halt the
+      run if handle_tool_error is unset). The model cannot tell a transient,
+      retryable failure from a permanent one, so it retries a charge that
+      already committed or abandons a call that would have succeeded on retry.
+      Returning a structured error object lets the model branch on the failure
+      mode. LC-102's max_iterations cap does not help — it bounds how many
+      steps the executor takes, not how the model interprets one failed step.
+    fix: >
+      Catch known failure modes and return a structured payload such as
+      `{"error": "...", "retryable": False}` instead of raising. Distinguish
+      transient faults (timeout, 503) from permanent ones (bad argument,
+      not-found) so the model can retry or escalate.

--- a/langchain/idempotency.yaml
+++ b/langchain/idempotency.yaml
@@ -1,0 +1,92 @@
+policy:
+  id: langchain_idempotency
+  name: LangChain mutating-tool idempotency
+  category: langchain
+  description: >
+    Rules that flag mutating LangChain / LangGraph tools (create/send/refund/...)
+    without an idempotency key. AgentExecutor and LangGraph re-invoke tools
+    under timeouts and ambiguous failures; without a key the same side-effecting
+    action can fire twice.
+
+rules:
+  - id: LC-009
+    title: Mutating LangChain tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). LangChain's
+      AgentExecutor and LangGraph ToolNode retry or re-select a tool when a
+      result times out or reads as inconclusive, and a lost response after the
+      side effect already committed is at-least-once delivery. Without an
+      idempotency key the same action fires twice — a duplicate charge, a
+      double-sent message, a repeated delete. LC-102's max_iterations bound
+      does not prevent this: it caps how many steps run, not whether one
+      mutating step is safe to retry. The downstream service must also honor
+      the key for this protection to be effective.
+    fix: >
+      Add an `idempotency_key: str` parameter and pass it through to the backing
+      API so a retried call is recognized and deduplicated rather than
+      re-executed.
+
+  - id: LC-016
+    title: TypeScript LangChain mutating tool has no idempotency key
+    severity: medium
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create
+            - send
+            - delete
+            - post
+            - update
+            - refund
+            - charge
+            - issue
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - requestId
+                - request_id
+                - txnId
+                - txn_id
+    explanation: >
+      This LangChain.js tool's name implies a side effect (create/send/refund/…)
+      but its Zod schema exposes no idempotency parameter. AgentExecutor and
+      LangGraph re-invoke tools when a result times out or reads as
+      inconclusive, and a lost response after the side effect committed is
+      at-least-once delivery — so the same charge, send, or delete can fire
+      twice. The prefix set matches both `create_charge` and `createCharge`
+      naming, so it fires on idiomatic TypeScript tool names.
+    fix: >
+      Add an `idempotencyKey` (or `requestId`) field to the tool's Zod schema,
+      thread it to the downstream API, and confirm that API treats a repeated
+      key as a no-op rather than a second mutation.


### PR DESCRIPTION
## Summary
- Add **LC-008**: Python LangChain tool raises without a structured error contract (`has_raise` + no `has_try_except`), matching CSDK-005 / OAI-008 / MCP-006 / ADK-005.
- Add **LC-009**: Python mutating LangChain tool has no idempotency key (`name_has_prefix` + negated `param_name_matches`), matching CREW-006 / PYD-007 / CSDK-006.
- Add **LC-016**: TypeScript LangChain.js counterpart of LC-009 (camelCase prefixes + Zod schema param names), matching CSDK-016.

LangChain already discovers `@tool` / `StructuredTool` / `tool()` and ships shell/SSRF/code-exec rules, but it was missing the error-contract and mutating-tool idempotency checks that the stronger packs have. AgentExecutor / LangGraph `ToolNode` retries do not make these safe: LC-102's `max_iterations` bounds steps, not whether one mutating step is safe to retry or how the model interprets an opaque `ToolMessage`.

No new predicates and no `schema_version` bump — both matches are already used by other packs.

Paired PRs (same branch name `feat/langchain-error-idempotency`):
- Engine fixture + tests: opened next
- Rulebook rationale: opened next

## Test plan
- [ ] `trustabl rules validate .` on this pack
- [ ] Engine `go test ./internal/rules/ -run TestPolicyRules` (fire + silent cases for all three IDs)
- [ ] Confirm LC-007 / LC-015 (network timeout, open PR #52) do not collide — this pack uses 008/009/016


Made with [Cursor](https://cursor.com)