### PR TITLE
feat(langchain): add LC-018, LC-019 tool description quality rules

### DIFF
--- a/langchain/tool_definition.yaml
+++ b/langchain/tool_definition.yaml
@@ -77,3 +77,63 @@ rules:
       Pass a one-sentence description in the tool() config (or the
       DynamicStructuredTool options) naming what the tool does, the inputs it
       expects, and what it returns. Write it for the model, not a human reader.
+
+  - id: LC-018
+    title: LangChain tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the LC-001 has-a-description check but carries a
+      placeholder marker instead of real content. LangChain derives the tool
+      description from the docstring and puts it in front of the model as the
+      tool's only selection signal, so a stub like "TODO: describe this tool" is
+      functionally indistinguishable from no description at all — the model
+      still has to guess from the function name. The failure is quiet and gets
+      worse with scale: LangChain agents are routinely handed a dozen or more
+      tools at once, and mis-selection between similarly named neighbors shows
+      up as wrong answers and wasted executor iterations rather than as an
+      error anyone can trace back to this docstring.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it rather than a
+      neighboring tool. Where the name alone is genuinely ambiguous, pass an
+      explicit description= at the @tool decorator instead of relying on the
+      docstring.
+
+  - id: LC-019
+    title: LangChain tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. LangChain passes this text to the model as the tool's only
+      selection signal, so a stub like "Gets data." leaves scope and
+      preconditions to guesswork. In an AgentExecutor loop the cost compounds:
+      each mis-selected call consumes an iteration against LC-102's
+      max_iterations budget, so a run can exhaust its steps re-trying tools it
+      picked badly and return nothing useful.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives.


### PR DESCRIPTION
Ports the CSDK-017/018 description-quality pair (merged in #40) to LangChain. LC-001 only checks that a docstring *exists*, so a tool whose docstring reads `"""TODO: describe this tool."""` or `"""Gets data."""` passes today while giving the model no selection signal.

The LangChain framing is its own on both counts:

- **Mis-selection scales badly here.** LangChain agents are routinely handed a dozen or more tools at once, so the model is picking between similarly named neighbors far more often than in a two-tool setup, and the failure is quiet — wrong answers, not errors anyone traces back to the docstring.
- **It costs the run, not just the answer.** Each mis-selected call consumes an iteration against LC-102's `max_iterations` budget, so a run can exhaust its steps re-trying tools it picked badly and return nothing useful.

LC-018's fix also points at the `@tool` decorator's explicit `description=` for cases where the function name is genuinely ambiguous, which is the LangChain-idiomatic escape hatch.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 208 rule(s) valid under rule schema version 14
```

Fire (one tool with `"""TODO: describe this tool."""`, one with `"""Gets data."""`): `LC-018, LC-019, LC-201`
Silent (full description naming when to prefer the neighboring tool): `LC-201`

LC-019 pairs `description_length_lt: 40` with `has_docstring: true` so it doesn't double-report against LC-001 on an empty docstring, same as CSDK-018.

No new predicates, so no `schema_version` bump.