### PR TITLE
feat(crewai): add CREW-010, CREW-011 tool description quality rules

### DIFF
--- a/crewai/tool_definition.yaml
+++ b/crewai/tool_definition.yaml
@@ -52,3 +52,60 @@ rules:
       Annotate every parameter with a concrete type (str, int, list[str], a
       Pydantic model, etc.). CrewAI propagates these annotations into the schema the
       model sees, so the model emits correctly-shaped arguments.
+
+  - id: CREW-010
+    title: CrewAI tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the CREW-001 has-a-description check but carries a
+      placeholder marker instead of real content. CrewAI puts the tool
+      description in front of the agent as its only basis for choosing between
+      the tools it holds, so a stub like "TODO: describe this tool" is
+      functionally indistinguishable from no description at all. In a crew the
+      consequence travels: an agent that picks the wrong tool produces a task
+      output that is threaded forward as context to every task behind it, so one
+      undescribed tool degrades work the agent that owns it never touches — and
+      CREW-104 delegation means peers can reach this tool on the strength of the
+      same placeholder.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the agent should reach for it rather than
+      a neighboring tool.
+
+  - id: CREW-011
+    title: CrewAI tool description is too short to guide agent selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. CrewAI passes this text to the agent as its only selection
+      signal, so a stub like "Gets data." leaves scope and preconditions to
+      guesswork. Each mis-selected call also spends one of the agent's CREW-110
+      max_iter steps, so an agent can hit its iteration cap and hand the next
+      task a half-finished result rather than an answer.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives.


### PR DESCRIPTION
Ports the CSDK-017/018 description-quality pair (merged in #40) to CrewAI. CREW-001 only checks that a docstring *exists*, so a tool whose docstring reads `"""TODO: describe this tool."""` or `"""Gets data."""` passes today while giving the agent no selection signal.

What makes the CrewAI framing its own is that **the consequence travels**. An agent that picks the wrong tool produces a task output that's threaded forward as context to every task behind it, so one undescribed tool degrades work the agent that owns it never touches. CREW-104 delegation compounds it: peers can reach this tool on the strength of the same placeholder. And each mis-selected call spends one of the agent's CREW-110 `max_iter` steps, so the agent can hit its cap and hand the next task a half-finished result rather than an answer.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 208 rule(s) valid under rule schema version 14
```

Fire (one tool with `"""TODO: describe this tool."""`, one with `"""Gets data."""`): `CREW-010, CREW-011, CREW-201`
Silent (full description naming when to prefer the neighboring tool): `CREW-201`

CREW-011 pairs `description_length_lt: 40` with `has_docstring: true` so it doesn't double-report against CREW-001 on an empty docstring, same as CSDK-018.

No new predicates, so no `schema_version` bump.