### PR TITLE
feat(autogen): add AG2-016, AG2-017 tool description quality rules

### DIFF
--- a/autogen/tool_definition.yaml
+++ b/autogen/tool_definition.yaml
@@ -54,3 +54,64 @@ rules:
       Annotate every parameter with a concrete type (str, int, list[str], a
       typing.Annotated description, etc.). AutoGen propagates these annotations into
       the schema the model sees, so the model emits correctly-shaped arguments.
+
+  - id: AG2-016
+    title: AutoGen tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the AG2-007 has-a-description check but carries a
+      placeholder marker instead of real content. AutoGen advertises the tool to
+      the assistant through this text, so a stub like "TODO: describe this tool"
+      is functionally indistinguishable from no description at all and the
+      assistant has to guess from the function name. The way AutoGen fails on a
+      bad guess is what makes this expensive: a wrongly chosen tool returns
+      something that does not answer the assistant's intent, the assistant reads
+      that as an inconclusive step and proposes another call, and the pair
+      trades rounds until AG2-004's max_round or AG2-006's auto-reply cap ends
+      the chat — burning the conversation budget on a selection problem no error
+      message points at.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the assistant should call it rather than a
+      neighboring tool. Passing an explicit description= to register_for_llm
+      overrides the docstring and is the clearer place to say it.
+
+  - id: AG2-017
+    title: AutoGen tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. AutoGen passes this text to the assistant as its only selection
+      signal, so a stub like "Gets data." leaves scope and preconditions to
+      guesswork. Each mis-selected call costs a full round of the conversation —
+      the assistant proposes, the executor runs, the result comes back unhelpful
+      — so a thin description spends the max_round budget rather than the run
+      producing an answer.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives, either in the docstring or via register_for_llm's
+      description= argument.


### PR DESCRIPTION
Ports the CSDK-017/018 description-quality pair (merged in #40) to AutoGen. AG2-007 only checks that a docstring *exists*, so a tool whose docstring reads `"""TODO: describe this tool."""` or `"""Gets data."""` passes today while giving the assistant no selection signal.

**How AutoGen fails on a bad guess is what makes this expensive**, and it's the part worth putting in the finding text. A wrongly chosen tool returns something that doesn't answer the assistant's intent; the assistant reads that as an inconclusive step and proposes another call; the pair trades rounds until AG2-004's `max_round` or AG2-006's auto-reply cap ends the chat. The conversation budget goes on a selection problem that no error message points at — nothing in the transcript says "the description was a stub".

Both fixes name `register_for_llm`'s `description=` argument, which overrides the docstring and is the clearer place to put it in this SDK.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 208 rule(s) valid under rule schema version 14
```

Fire (one tool with `"""TODO: describe this tool."""`, one with `"""Gets data."""`): `AG2-016, AG2-017, AG2-201`
Silent (full description naming when to prefer the neighboring tool): `AG2-201`

AG2-017 pairs `description_length_lt: 40` with `has_docstring: true` so it doesn't double-report against AG2-007 on an empty docstring, same as CSDK-018.

No new predicates, so no `schema_version` bump.