### PR TITLE
feat(pydantic_ai): add PYD-012, tool prints to stdout for diagnostics

### DIFF
--- a/pydantic_ai/observability.yaml
+++ b/pydantic_ai/observability.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: pydantic_ai_observability
+  name: Pydantic AI tool observability hygiene
+  category: pydantic_ai
+  description: >
+    Rules covering how a Pydantic AI tool emits diagnostics. A tool body that
+    prints to stdout writes outside the SDK's instrumentation, so the record
+    reaches neither the model nor the trace the rest of the run is captured in.
+
+rules:
+  - id: PYD-012
+    title: Pydantic AI tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool body calls print(), which writes to the process's stdout. The
+      model never sees it — only the return value flows back into the agent run
+      — so the output silently disappears in any deployment that captures
+      structured records rather than raw stdout. It is a bigger loss in this SDK
+      than in most: Pydantic AI emits OpenTelemetry spans for each run and tool
+      call, so everything around this print is already correlated to a trace,
+      and a bare print is the one diagnostic that lands outside it, unattached
+      to the run that produced it. If the tool is ever also served over an MCP
+      stdio transport, the loose print frames interleave with JSON-RPC messages
+      and corrupt the stream.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)), or attach the detail to the
+      current span via Logfire or the OpenTelemetry API so it is correlated with
+      the run that produced it. If the information needs to reach the model,
+      return it as part of the tool's result instead.


### PR DESCRIPTION
Ports OAI-010 to Pydantic AI — the observability dimension isn't covered in any of the five newer packs.

**The loss is larger in this SDK than in the OpenAI pack, which is what the rule text leads with.** Pydantic AI emits OpenTelemetry spans for each run and tool call, so everything around this `print` is already correlated to a trace — the bare print is the one diagnostic that lands outside it, unattached to the run that produced it. That's a sharper argument than "it disappears from logs," and it points at a better fix: attach the detail to the current span via Logfire or the OTel API, rather than only swapping in a module logger.

The stdio-transport corruption note from OAI-010 carries over, since a Pydantic AI tool served over an MCP stdio transport has the same JSON-RPC interleaving problem.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`print(f"looking up {order_id}")` in the tool body): `PYD-012, PYD-101, PYD-201`
Silent (`logger.info("looking up %s", order_id)`): `PYD-101, PYD-201`

`has_print_call` matches a bare `print` callee, so `pprint` and other attribute calls don't false-positive.

No new predicates, so no `schema_version` bump.