### PR TITLE
feat(crewai): add CREW-012, tool prints to stdout for diagnostics

### DIFF
--- a/crewai/observability.yaml
+++ b/crewai/observability.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: crewai_observability
+  name: CrewAI tool observability hygiene
+  category: crewai
+  description: >
+    Rules covering how a CrewAI tool emits diagnostics. A tool body that prints
+    to stdout writes into the same channel the crew's own verbose narration uses,
+    so the record is neither visible to the agent nor separable from the run
+    commentary around it.
+
+rules:
+  - id: CREW-012
+    title: CrewAI tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool body calls print(), which writes to the process's stdout. The
+      agent never sees it — only the return value becomes the observation it
+      reasons over — so the output silently disappears in any deployment that
+      captures structured records rather than raw stdout. CrewAI makes it worse
+      than a lost log line: a crew running with verbose=True is already writing
+      its own narration to that same stream, so a tool print is interleaved into
+      run commentary from several agents at once with nothing marking which
+      agent, task, or tool call emitted it. What looks like working diagnostics
+      in a terminal is unattributable the moment the crew runs anywhere else.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)) so the record carries its own
+      module and level and lands in the application's log sink rather than the
+      crew's narration stream. If the information needs to reach the agent,
+      return it as part of the tool's result instead.


### PR DESCRIPTION
Ports OAI-010 to CrewAI — the observability dimension isn't covered in any of the five newer packs.

**CrewAI makes this worse than a lost log line, which is what the rule text leads with.** A crew running with `verbose=True` is already writing its own narration to stdout, so a tool `print` gets interleaved into run commentary from several agents at once, with nothing marking which agent, task, or tool call emitted it. That's the trap: it looks like working diagnostics in a terminal and becomes unattributable the moment the crew runs anywhere else. The fix names what a module logger buys you here specifically — the record carries its own module and level and lands in the application's log sink rather than the crew's narration stream.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`print(f"looking up {order_id}")` in the tool body): `CREW-012, CREW-201`
Silent (`logger.info("looking up %s", order_id)`): `CREW-201`

`has_print_call` matches a bare `print` callee, so `pprint` and other attribute calls don't false-positive.

No new predicates, so no `schema_version` bump.