### PR TITLE
feat(autogen): add AG2-018, tool prints to stdout for diagnostics

### DIFF
--- a/autogen/observability.yaml
+++ b/autogen/observability.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: autogen_observability
+  name: AutoGen tool observability hygiene
+  category: autogen
+  description: >
+    Rules covering how a registered AutoGen tool emits diagnostics. A tool body
+    that prints to stdout writes into the same stream the conversation itself is
+    narrated on, so the record is neither visible to the agents nor separable
+    from the transcript around it.
+
+rules:
+  - id: AG2-018
+    title: AutoGen tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The registered tool's body calls print(), which writes to the process's
+      stdout. Neither agent sees it — only the return value is posted back into
+      the conversation as the executor's reply — so the output silently
+      disappears in any deployment that captures structured records rather than
+      raw stdout. AutoGen makes that especially deceptive: the conversation
+      itself is narrated to stdout, so a tool print lands in the middle of the
+      transcript and reads as though it were part of the exchange, when in fact
+      it is invisible to the agents reasoning over it and carries no marker for
+      which round or which tool call produced it. Anyone reconstructing the run
+      from a log sink rather than a terminal loses it entirely.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)) so the record carries its own
+      module and level and lands in the application's log sink rather than the
+      conversation narration. If the information needs to reach the assistant,
+      return it as part of the tool's result, which is the only channel the
+      agents actually read.


### PR DESCRIPTION
Ports OAI-010 to AutoGen — the observability dimension isn't covered in any of the five newer packs.

**AutoGen makes this especially deceptive, which is what the rule text leads with.** The conversation itself is narrated to stdout, so a tool `print` lands in the middle of the transcript and *reads as though it were part of the exchange* — when in fact it's invisible to the agents reasoning over it and carries no marker for which round or which tool call produced it. Anyone reconstructing the run from a log sink rather than a terminal loses it entirely.

The fix points at the return value as "the only channel the agents actually read," which is the distinction that matters in a two-agent reply loop.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`print(f"looking up {order_id}")` in a tool registered via `register_for_llm`/`register_for_execution`): `AG2-018, AG2-201`
Silent (`logger.info("looking up %s", order_id)`): `AG2-201`

`has_print_call` matches a bare `print` callee, so `pprint` and other attribute calls don't false-positive.

No new predicates, so no `schema_version` bump.