### PR TITLE
feat(langchain): add LC-008, LC-016 — mutating tool has no idempotency key

### DIFF
--- a/langchain/idempotency.yaml
+++ b/langchain/idempotency.yaml
@@ -1,0 +1,95 @@
+policy:
+  id: langchain_idempotency
+  name: LangChain mutating-tool idempotency
+  category: langchain
+  description: >
+    Flags mutating LangChain tools (create/send/refund/...) without an
+    idempotency key. AgentExecutor and LangGraph re-invoke tool nodes under
+    timeouts and ambiguous failures, so without a key the same side effect
+    can fire twice.
+
+rules:
+  - id: LC-008
+    title: Mutating LangChain tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). LangChain retries
+      a tool call when AgentExecutor or a LangGraph tool node times out, when
+      the model re-selects the same tool after an inconclusive result, or when
+      a response is lost after the side effect already committed
+      (at-least-once delivery). Without an idempotency key the same action can
+      fire twice — a duplicate charge, a double-sent message, a repeated
+      delete. An iteration cap such as max_iterations does not help: it bounds
+      how many steps the executor takes, not whether one mutating step may run
+      twice. The downstream service must also honor the key for this
+      protection to be effective.
+    fix: >
+      Add an `idempotency_key: str` parameter and pass it through to the backing
+      API so a retried call is recognized and deduplicated rather than
+      re-executed.
+
+  - id: LC-016
+    title: TypeScript LangChain mutating tool has no idempotency key
+    severity: medium
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create
+            - send
+            - delete
+            - post
+            - update
+            - refund
+            - charge
+            - issue
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - requestId
+                - request_id
+                - txnId
+                - txn_id
+    explanation: >
+      This LangChain.js tool's name implies a side effect (create/send/refund/…)
+      but its Zod schema exposes no idempotency field. Retries happen outside
+      the tool — createReactAgent / AgentExecutor re-issues after a timeout,
+      the model re-selects the same tool after an inconclusive result, or a
+      response is lost after the side effect already committed — so the same
+      charge, send, or delete can fire twice. The prefix set matches both
+      `create_charge` and `createCharge`, so it fires on idiomatic TypeScript
+      tool names. Without a key the model and the graph cannot make the retry
+      safe.
+    fix: >
+      Add an `idempotencyKey` (or `requestId`) field to the tool's Zod schema,
+      thread it to the downstream API, and confirm that API treats a repeated
+      key as a no-op rather than a second mutation.


### PR DESCRIPTION
LangChain was the only one of seven packs without an idempotency rule, so this adds LC-008 for Python and LC-016 for TypeScript. Same `name_has_prefix` + `not param_name_matches` predicates as CSDK-006/016, OAI-009/019, ADK-006, CREW-006 and MCP-007, and the same medium/0.55 and medium/0.5 calibration — I'd rather not have LangChain drift from the family on a rule this well established. No new predicates, so no schema bump.

The explanation text is LangChain-specific rather than shared because the retry surfaces are. `AgentExecutor` retries a timed-out step, a LangGraph tool node re-enters on a retry policy that's configured nowhere near the tool definition, and the model can simply pick the same tool again after an ambiguous result. The middle one is what convinced me this is worth flagging statically — the tool author frequently can't see that retries are enabled from the file they're editing.

Worth saying up front that LC-102's iteration cap doesn't cover this, since that's the obvious "we already handle it" objection. It bounds how many times the loop runs; a capped loop that charged a card twice has still charged it twice.

I scanned a sample project rather than only running the unit tests. `create_order` fires; `create_refund`, which has the same mutating prefix but takes an `idempotency_key`, stays quiet; `get_order` stays quiet. The same three shapes behave the same way for LC-016 (`createCharge` / `createPayout` / `getBalance`). The guarded-but-mutating case is the one I cared about — a rule that fires on both is just noise.

Known misses, since they set the confidence: the prefix list isn't a verb ontology, so `submit_transfer` or `apply_discount` slip through, and a tool that accepts an `idempotency_key` and never forwards it downstream goes quiet while staying unsafe. That's why 0.55 and not higher.

Fixture mirror is [trustabl#123](https://github.com/trustabl/trustabl/pull/123), rationale doc is [trustabl-rulebook#43](https://github.com/trustabl/trustabl-rulebook/pull/43). This one needs to merge first — `rules-sync` looks up the paired branch with `git ls-remote` against this repo, so it can't see a branch on a fork, and the engine PR's check stays red until this lands.

Unrelated to these IDs, but flagging it since I just went through the same exercise on my MCP PR: #52 and #81 both claim `LC-007`. Whichever merges second will need a renumber, and a duplicate ID stops the loader at startup rather than failing a test.

Made with [Cursor](https://cursor.com)
