### PR TITLE
feat: add error-contract rules to the four packs that lacked them

### DIFF
--- a/autogen/error_handling.yaml
+++ b/autogen/error_handling.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: autogen_error_handling
+  name: AutoGen error contract hygiene
+  category: autogen
+  description: >
+    Rules covering how an AutoGen / AG2 tool surfaces failures back to the
+    conversation. A registered tool's return value becomes a message in the chat
+    history, so an uncaught exception is what the next speaker reasons over.
+
+rules:
+  - id: AG2-013
+    title: AutoGen tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      An AutoGen tool that raises produces a tool-response message carrying the
+      stringified exception, and that message stays in the conversation history
+      for every subsequent turn. The model cannot branch on it — there is no field
+      separating a malformed argument from an unreachable dependency — so it
+      re-calls the tool or hands the failure to another agent as prose. In a group
+      chat the bad message is replayed to every participant on each round, so one
+      opaque traceback consumes context for the rest of the run.
+    fix: >
+      Catch the failure modes you expect and return a structured result the model
+      can act on — e.g. {"error": "...", "retryable": true} — so the response that
+      lands in the history is something the next speaker can reason about. Reserve
+      raises for unrecoverable states.

--- a/crewai/error_handling.yaml
+++ b/crewai/error_handling.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: crewai_error_handling
+  name: CrewAI error contract hygiene
+  category: crewai
+  description: >
+    Rules covering how a CrewAI tool surfaces failures back to the agent. A tool
+    that raises is caught by the executor and replayed to the model as text, so
+    an uncaught exception becomes the model's only account of what failed.
+
+rules:
+  - id: CREW-007
+    title: CrewAI tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      A CrewAI tool that raises hands the executor an exception it can only
+      stringify back into the agent's scratchpad. The model sees a message, not a
+      status: it cannot distinguish an invalid argument it should fix from a
+      transient timeout it should retry, so it burns iterations re-calling the
+      tool the same way until max_iter stops the agent. Because the tool's output
+      is also what a delegating agent reads, an opaque error propagates across the
+      crew rather than staying local to the task that failed.
+    fix: >
+      Catch the failures you expect and return a structured result the model can
+      branch on — e.g. {"error": "...", "retryable": true} — and keep raises for
+      states no retry can fix. Name the failing input in the message so the model
+      can correct its next call instead of repeating it.

--- a/langchain/error_handling.yaml
+++ b/langchain/error_handling.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: langchain_error_handling
+  name: LangChain error contract hygiene
+  category: langchain
+  description: >
+    Rules covering how a LangChain / LangGraph tool surfaces failures back to
+    the agent. A tool that raises is converted into a message the model reads as
+    prose, so an uncaught exception becomes the model's only signal about what
+    went wrong.
+
+rules:
+  - id: LC-007
+    title: LangChain tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      When a LangChain tool raises, the executor either aborts the run or, with
+      handle_tool_error set, stringifies the exception into a ToolMessage the
+      model reads as prose. Either way the model gets no field it can branch on:
+      it cannot tell a bad argument it should correct from a remote outage it
+      should retry from a permission denial it should stop on, so it typically
+      re-calls the tool with the same arguments. The stringified traceback can
+      also carry internal paths and stack frames into the transcript.
+    fix: >
+      Catch the failure modes you expect and return a structured result the model
+      can act on — e.g. {"error": "...", "retryable": true} — reserving raises
+      for genuinely unrecoverable states. If you do want the executor to relay
+      errors, set handle_tool_error to a function that maps the exception to that
+      same structured shape rather than to True.

--- a/pydantic_ai/error_handling.yaml
+++ b/pydantic_ai/error_handling.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: pydantic_ai_error_handling
+  name: Pydantic AI error contract hygiene
+  category: pydantic_ai
+  description: >
+    Rules covering how a Pydantic AI tool surfaces failures back to the model.
+    The framework has an explicit retry channel (ModelRetry); an arbitrary
+    exception bypasses it and ends the run instead.
+
+rules:
+  - id: PYD-008
+    title: Pydantic AI tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      Pydantic AI distinguishes two kinds of tool failure: a ModelRetry, which is
+      fed back to the model as guidance so it can correct its arguments and try
+      again, and any other exception, which propagates out of agent.run() and ends
+      the run. A tool that raises whatever the underlying library raised takes the
+      second path for failures that belonged in the first — a validation error or a
+      404 aborts the whole run rather than giving the model a chance to fix its
+      call.
+    fix: >
+      Catch the failures you expect and either raise ModelRetry with a message
+      telling the model what to change, or return a structured result it can
+      branch on — e.g. {"error": "...", "retryable": true}. Let only genuinely
+      unrecoverable exceptions escape the tool.


### PR DESCRIPTION
> Paired with the engine PR on a branch of the **same name**, so `rules-sync` resolves this pack. Neither should merge alone — `check-rules-sync.sh` fails if they do.

## The gap

Four packs ship a rule for a tool that raises without catching:

| pack | rule |
|---|---|
| Claude Agent SDK | CSDK-005 |
| OpenAI Agents SDK | OAI-008 |
| Google ADK | ADK-005 |
| MCP | MCP-006 |

LangChain, CrewAI, AutoGen and Pydantic AI ship none. The same defect goes unreported in four of the five packs the project lists as its weakest coverage — and error handling is one of the named priority areas.

This adds **LC-007, CREW-007, AG2-013, PYD-008**, using the same `has_raise: true` + `has_try_except: false` predicate pair, at the same `low` / `0.6` severity and confidence as the four that shipped.

## Why the text is per-SDK, not shared

Per `CLAUDE.md` — "never widen `applies_to` across SDKs casually … makes the user-facing text lie". The consequence genuinely differs in each framework, so each rule names its own:

- **LangChain** — the executor stringifies the exception into a `ToolMessage` the model reads as prose (or aborts the run outright, without `handle_tool_error`).
- **CrewAI** — it lands in the agent scratchpad, and a *delegating* agent reads the same opaque text, so the failure propagates across the crew.
- **AutoGen** — it becomes a tool-response message that stays in conversation history and is re-sent to every group-chat participant on each round.
- **Pydantic AI** — the framework has an explicit `ModelRetry` channel. A bare raise bypasses it and propagates out of `agent.run()`, ending the run for a failure the model could have corrected.

The `fix` text differs accordingly — the Pydantic AI one prescribes `ModelRetry`, the LangChain one covers `handle_tool_error`.

## Verified end to end

Not just unit-tested — built the engine and scanned real sample projects with `--rules-repo` pointed at this branch:

```
$ trustabl scan /tmp/lcdemo  --rules-ref feat/error-handling-... --format json
LC-007   [low] lookup_order  tools.py:5 — LangChain tool raises exceptions without a structured error contract
$ trustabl scan /tmp/crewdemo ...
CREW-007 [low] fetch_invoice tools.py:5 — CrewAI tool raises exceptions without a structured error contract
$ trustabl scan /tmp/ag2demo ...
AG2-013  [low] load_profile  tools.py:6 — AutoGen tool raises exceptions without a structured error contract
$ trustabl scan /tmp/pyddemo ...
PYD-008  [low] get_account   tools.py:7 — Pydantic AI tool raises exceptions without a structured error contract
```

Each sample also contains a second tool that catches and returns `{"error", "retryable"}`. None of them fired on it.

## IDs

`LC-007`, `CREW-007`, `AG2-013`, `PYD-008` — all previously unused. `AG2-003` is also free but was deliberately skipped in case it is a retired ID.