### PR TITLE
feat(mcp): add MCP-023, tool prints to stdout, corrupting a stdio transport

### DIFF
--- a/mcp/observability.yaml
+++ b/mcp/observability.yaml
@@ -1,0 +1,41 @@
+policy:
+  id: mcp_observability
+  name: MCP tool observability hygiene
+  category: mcp
+  description: >
+    Rules covering how an MCP tool handler emits diagnostics. On a stdio
+    server — the default transport — stdout is the protocol channel, so a
+    handler that prints to it is not writing a log line, it is writing into the
+    JSON-RPC frame stream.
+
+rules:
+  - id: MCP-023
+    title: MCP tool prints to stdout, corrupting a stdio transport
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool handler calls print(), which writes to the process's stdout. On
+      an MCP server using the stdio transport — the default for FastMCP and the
+      usual way an editor or desktop client launches a server — stdout is not a
+      log sink, it is the protocol channel: the client reads newline-delimited
+      JSON-RPC messages from it. A loose print interleaves with those frames, so
+      the client hits a parse error on a line that is not JSON and, depending on
+      the client, drops the response, logs a protocol error, or tears down the
+      connection. The failure does not look like the cause: the symptom is a
+      tool call that returns nothing or a server that disconnects mid-session,
+      while the print that broke it reads like harmless debugging. A server run
+      over HTTP or SSE instead escapes the corruption, but the diagnostic is
+      still lost — the model never sees stdout, only the return value.
+    fix: >
+      Remove the print(). Diagnostics from an MCP server belong on stderr, which
+      the transport leaves alone and clients typically capture as server logs —
+      emit through a module logger (logging.getLogger(__name__)) configured with
+      a StreamHandler on sys.stderr, and make sure nothing in the process
+      reconfigures logging onto stdout. If the information needs to reach the
+      model, return it as part of the tool's result instead.


### PR DESCRIPTION
MCP had no observability rule. OpenAI ships OAI-010 and ADK ships ADK-009 for the same `print()` pattern — both at `low` severity, framed as a lost-diagnostic problem.

**It isn't a lost-diagnostic problem here, which is why this ships at `medium` instead.** On a stdio server — the FastMCP default, and the usual way an editor or desktop client launches a server — stdout *is* the protocol channel. The client reads newline-delimited JSON-RPC messages from it, so a loose `print` interleaves with those frames: the client hits a parse error on a line that isn't JSON and, depending on the client, drops the response, logs a protocol error, or tears down the connection.

The reason it's worth flagging rather than leaving to review is that **the failure doesn't look like its cause**. The symptom is a tool call that returns nothing, or a server that disconnects mid-session; the `print` that broke it reads like harmless debugging and sits nowhere near the error.

OAI-010's explanation already anticipates exactly this — it warns that a tool "ever exposed over an MCP stdio server" will corrupt the stream. This rule is that case as the primary reading rather than the footnote.

Confidence is 0.7 rather than higher because a server run over HTTP or SSE escapes the corruption — though it still loses the diagnostic, since the model only ever sees the return value. The fix names **stderr** specifically, which the transport leaves alone and clients typically capture as server logs, plus the caveat about nothing in the process reconfiguring logging onto stdout.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`print(f"looking up {order_id}")` in a FastMCP tool handler): `MCP-023`
Silent (`logger.info(...)` with `basicConfig(stream=sys.stderr)`): no findings

`has_print_call` matches a bare `print` callee, so `pprint` and other attribute calls don't false-positive.

No new predicates, so no `schema_version` bump.