### PR TITLE
feat(claude_sdk): add CSDK-019, tool prints to stdout for diagnostics

### DIFF
--- a/claude_sdk/observability.yaml
+++ b/claude_sdk/observability.yaml
@@ -1,0 +1,41 @@
+policy:
+  id: claude_sdk_observability
+  name: Claude Agent SDK tool observability hygiene
+  category: claude_sdk
+  description: >
+    Rules covering how a Claude Agent SDK tool emits diagnostics. A tool body
+    that prints to stdout writes somewhere neither the model nor the
+    application's log sink reads, and can corrupt a transport that uses stdout
+    as a protocol channel.
+
+rules:
+  - id: CSDK-019
+    title: Tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - claude_sdk_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool body calls print(), which writes diagnostics to the process's
+      stdout. The model never sees that output — only the tool's return value
+      flows back into the agent loop — so the print silently disappears in any
+      deployment that captures structured records rather than raw stdout. Two
+      Claude-SDK-specific consequences make it worse than a lost log line. A
+      tool defined in a Python SDK server is commonly served to the agent over
+      an MCP stdio transport, where stdout carries the JSON-RPC frames: a loose
+      print interleaves with them and the client hits a parse error on a line
+      that is not JSON. And when the SDK is driven programmatically, the host
+      application is reading the SDK's own message stream, so tool prints land
+      interleaved with it rather than in the application's logs, attributable to
+      no particular turn or tool call.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)) so the record carries its module
+      and level and lands in the application's log sink; where the tool may be
+      served over a stdio transport, make sure that handler writes to stderr,
+      which the transport leaves alone. If the information needs to reach the
+      model, include it in the tool's return value instead.


### PR DESCRIPTION
Claude SDK and MCP were the two mature packs with no observability rule. OpenAI ships OAI-010 and ADK ships ADK-009 for the same `print()` pattern.

Two Claude-SDK-specific consequences go beyond the lost-log-line framing OAI-010 uses:

- **A Python SDK tool is commonly served to the agent over an MCP stdio transport**, where stdout carries the JSON-RPC frames. A loose print interleaves with them and the client hits a parse error on a line that isn't JSON.
- **When the SDK is driven programmatically**, the host application is already reading the SDK's own message stream — so tool prints land interleaved with it rather than in the application's logs, attributable to no particular turn or tool call.

The fix reflects the first point: where the tool may be served over stdio, the log handler needs to write to **stderr**, which the transport leaves alone. Swapping `print` for a logger that still defaults to stdout doesn't fix that case.

Severity/confidence match OAI-010 (`low` / 0.65) since the dominant case here is still the lost diagnostic. The sharper stdio-corruption case is the primary reading in MCP-023 (#82), where stdio is the default transport.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 86 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`print(...)` in a `@tool`-decorated handler): `CSDK-002, CSDK-019, CSDK-203`
Silent (`logger.info(...)` with `basicConfig(stream=sys.stderr)`): `CSDK-002, CSDK-203`

(CSDK-002 and CSDK-203 are pre-existing rules firing on the fixture's untyped `args` param and missing CLAUDE.md.)

`has_print_call` matches a bare `print` callee, so `pprint` and other attribute calls don't false-positive.

No new predicates, so no `schema_version` bump.