### PR TITLE
feat(claude_sdk): add CSDK-020, TypeScript tool HTTP call has no timeout

### DIFF
--- a/claude_sdk/network.yaml
+++ b/claude_sdk/network.yaml
@@ -53,3 +53,34 @@ rules:
     fix: >
       Pass `timeout=` (typically 5–30s) to the request. Surface failures as a
       structured error the model can react to.
+
+  - id: CSDK-020
+    title: TypeScript Claude SDK tool HTTP call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - claude_sdk_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This TypeScript Claude SDK tool makes an outbound HTTP call (fetch /
+      axios / got / undici) with no deadline — no signal, timeout, or
+      abortSignal option. Node's fetch has no implicit deadline, so a slow or
+      unresponsive host blocks the tool callback until the socket eventually
+      dies. Because the call sits inside the agent's turn, that stalls the
+      conversation rather than failing it: the model gets no result and no
+      error, the turn cannot advance, and a max_turns cap does not help because
+      the run is stuck inside a single turn rather than taking too many. In a
+      server embedding the SDK it also holds the request worker for the
+      duration. The exposure compounds with CSDK-013: a tool that fetches a
+      model-controlled URL and cannot time out can be pointed at an internal
+      host that simply never answers.
+    fix: >
+      Attach a deadline. On modern runtimes,
+      await fetch(url, { signal: AbortSignal.timeout(15_000) }); on older ones,
+      create an AbortController, abort it from a setTimeout, pass
+      controller.signal, and clear the timer in a finally. axios and got take a
+      timeout option directly. Return the abort as a structured tool error so
+      the model can retry or route around it instead of the turn hanging.


### PR DESCRIPTION
CSDK-003 covers the Python side of network timeouts; the TypeScript half was missing, even though this pack ships TS rules throughout (CSDK-010..014, CSDK-120..131). OpenAI (OAI-016, OAI-024) and the Vercel AI SDK (VAI-011) already use `has_http_call_without_timeout` for exactly this.

The consequence framing is what makes it worth stating rather than porting VAI-011's text: **an unresponsive host stalls the conversation rather than failing it.** The model gets no result and no error, so the turn can't advance — and a `max_turns` cap doesn't help, because the run is stuck *inside* a single turn rather than taking too many. In a server embedding the SDK it also holds the request worker for the duration.

Compounds with CSDK-013 the way VAI-011 compounds with VAI-003: a tool that fetches a model-controlled URL and can't time out can be pointed at an internal host that simply never answers.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (bare `await fetch(...)` in a `tool(...)` handler): `CSDK-013, CSDK-020, CSDK-203`
Silent (`signal: AbortSignal.timeout(15_000)`): `CSDK-013, CSDK-203`

(CSDK-013 is the pre-existing SSRF rule firing on the fixture's template-string URL — which is also the compounding case the explanation describes. CSDK-203 is the missing-CLAUDE.md repo rule.)

No new predicates, so no `schema_version` bump.