### PR TITLE
feat(mcp): add MCP-024, TypeScript tool HTTP call has no timeout

### DIFF
--- a/mcp/network.yaml
+++ b/mcp/network.yaml
@@ -51,3 +51,36 @@ rules:
       Pass timeout= (typically 5-30 seconds depending on the endpoint) to every
       outbound call. Return the timeout to the client as a structured tool error
       rather than letting the handler block.
+
+  - id: MCP-024
+    title: TypeScript MCP tool HTTP call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This TypeScript MCP tool handler makes an outbound HTTP call (fetch /
+      axios / got / undici) with no deadline — no signal, timeout, or
+      abortSignal option. Node's fetch has no implicit deadline, so a slow or
+      unresponsive upstream blocks the handler until the socket eventually
+      dies. The stall crosses the server's trust boundary rather than staying
+      local: the connecting client is waiting on a JSON-RPC response that never
+      arrives, and because MCP gives it no way to cancel an in-flight tool call,
+      the client is left to its own timeout, an abandoned request, or a hung
+      session. Nothing in the response says why. On a stdio server the effect is
+      worse than one slow tool, since a single process serves the connection and
+      a handler parked on a dead socket is holding it. The exposure compounds
+      with MCP-013: a handler that fetches a caller-controlled URL and cannot
+      time out can be steered at an internal host that never answers.
+    fix: >
+      Attach a deadline. On modern runtimes,
+      await fetch(url, { signal: AbortSignal.timeout(15_000) }); on older ones,
+      create an AbortController, abort it from a setTimeout, pass
+      controller.signal, and clear the timer in a finally. axios and got take a
+      timeout option directly. Return the abort as a structured tool result the
+      model can act on, so the client learns the upstream was unreachable rather
+      than waiting on a response that is not coming.


### PR DESCRIPTION
MCP-004 covers the Python side of network timeouts; the TypeScript half was missing, even though the pack ships TS rules (MCP-011, MCP-013). OpenAI (OAI-016, OAI-024) and the Vercel AI SDK (VAI-011) already use `has_http_call_without_timeout` for exactly this.

**What makes the MCP case its own is that the stall crosses the server's trust boundary rather than staying local.** The connecting client is waiting on a JSON-RPC response that never arrives — and MCP gives it no way to cancel an in-flight tool call, so it's left to its own timeout, an abandoned request, or a hung session, with nothing in the response saying why. The server author never sees the symptom; the client's users do.

On a stdio server it's worse than one slow tool: a single process serves the connection, so a handler parked on a dead socket is holding it.

Compounds with MCP-013 the same way VAI-011 compounds with VAI-003 — a handler that fetches a caller-controlled URL and can't time out can be steered at an internal host that never answers.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (bare `await fetch(...)` in a `server.tool(...)` handler): `MCP-013, MCP-024`
Silent (`signal: AbortSignal.timeout(15_000)`): `MCP-013`

(MCP-013 is the pre-existing SSRF rule firing on the fixture's template-string URL — also the compounding case the explanation describes.)

No new predicates, so no `schema_version` bump.