### PR TITLE
feat(google_adk): add ADK-114, TypeScript FunctionTool HTTP call has no timeout

### DIFF
--- a/google_adk/network.yaml
+++ b/google_adk/network.yaml
@@ -51,3 +51,37 @@ rules:
       Pass `timeout=` (typically 5–30 seconds) to the request. Choose a
       value that's tight enough to fail fast and loose enough to allow
       legitimate slow responses for this endpoint.
+
+  - id: ADK-114
+    title: TypeScript FunctionTool HTTP call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - adk_function_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This TypeScript ADK FunctionTool makes an outbound HTTP call (fetch /
+      axios / got / undici) with no deadline — no signal, timeout, or
+      abortSignal option. Node's fetch has no implicit deadline, so a slow or
+      unresponsive host blocks the tool callback until the socket eventually
+      dies. What that costs depends on where the tool sits in the agent tree,
+      and the composition ADK encourages makes it worse rather than better: a
+      stalled tool inside a SequentialAgent blocks every step after it, and
+      inside a ParallelAgent the whole fan-out waits on its slowest branch, so
+      one unresponsive host stalls work that has nothing to do with it.
+      ADK-108's max_iterations bounds how many times a LoopAgent goes round, not
+      how long one tool call may run, so no configured limit breaks the stall.
+      The exposure compounds with ADK-016: a tool that fetches a
+      caller-controlled URL and cannot time out can be steered at an internal
+      host that never answers.
+    fix: >
+      Attach a deadline. On modern runtimes,
+      await fetch(url, { signal: AbortSignal.timeout(15_000) }); on older ones,
+      create an AbortController, abort it from a setTimeout, pass
+      controller.signal, and clear the timer in a finally. axios and got take a
+      timeout option directly. Return the abort as a structured tool result so
+      the agent can react to an unreachable upstream rather than the branch
+      hanging.


### PR DESCRIPTION
ADK-003 covers the Python side of network timeouts; the TypeScript half was missing, even though the pack ships TS rules (ADK-013, ADK-015, ADK-016, ADK-109). OpenAI (OAI-016, OAI-024) and the Vercel AI SDK (VAI-011) already use `has_http_call_without_timeout` for exactly this.

**The composition ADK encourages makes the stall worse rather than better**, which is the part worth having in the finding text:

- inside a `SequentialAgent`, a stalled tool blocks every step after it;
- inside a `ParallelAgent`, the whole fan-out waits on its slowest branch — so one unresponsive host stalls work that has nothing to do with it.

And the limit people reach for doesn't apply: **ADK-108's `max_iterations` bounds how many times a `LoopAgent` goes round, not how long one tool call may run.** No configured limit breaks this stall.

Compounds with ADK-016 the same way VAI-011 compounds with VAI-003 — a tool that fetches a caller-controlled URL and can't time out can be steered at an internal host that never answers.

Numbered ADK-114 to leave room for ADK-111 in the open PR #51 and ADK-112 in my #79.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (bare `await fetch(...)` in a `new FunctionTool({ ..., execute })` handler): `ADK-016, ADK-114, ADK-201`
Silent (`signal: AbortSignal.timeout(15_000)`): `ADK-016, ADK-201`

(ADK-016 is the pre-existing TS SSRF rule firing on the template-string URL — also the compounding case described. ADK-201 is the missing-AGENTS.md repo rule.)

My first fixture used `new FunctionTool(fn, {...})` and nothing fired, including the pre-existing TS rules — the adk-js shape is the options-object form with an `execute` callback. Worth flagging since the Python `FunctionTool(fn)` wrapper reads as the obvious analogue and isn't what the TS SDK does.

No new predicates, so no `schema_version` bump.