### PR TITLE
feat(claude_sdk): add CSDK-021, CSDK-022 TypeScript description quality rules

### DIFF
--- a/claude_sdk/tool_definition.yaml
+++ b/claude_sdk/tool_definition.yaml
@@ -183,3 +183,61 @@ rules:
       Expand the description to at least a full sentence covering inputs,
       outputs, and the situation in which this tool should be used over
       alternatives.
+
+  - id: CSDK-021
+    title: TypeScript Claude SDK tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - claude_sdk_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The tool sets a description, so it passes CSDK-014, but the string is a
+      placeholder rather than real content. That leaves the tool in exactly the
+      state CSDK-014 exists to prevent: the TypeScript SDK has no docstring
+      fallback, so this argument is the entire account of the tool in the
+      prompt, and "TODO: describe this tool" tells the model nothing the tool
+      name did not. Nothing reports it — the SDK does not warn, the Zod schema
+      still validates, and the only symptom is a tool the model calls at the
+      wrong moment or never reaches for at all.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it rather than a
+      neighboring tool. The SDK passes the string to the model verbatim, so
+      write it for the model rather than a human maintainer.
+
+  - id: CSDK-022
+    title: TypeScript Claude SDK tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - claude_sdk_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. With no docstring fallback in the TypeScript SDK, a stub like
+      "Gets data." is the whole prompt-side account of the tool, so scope and
+      preconditions are left to guesswork. The Zod input schema does not close
+      the gap: it constrains the shape of the arguments once the model has
+      decided to call this tool, and says nothing about whether calling it was
+      the right move.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives. Where two tools are easy to confuse, say in each which one
+      the other case belongs to.


### PR DESCRIPTION
CSDK-017/018 (merged in #40) cover the Python side of description quality; the TypeScript half was missing. CSDK-014 only checks that a description *exists*, so a tool whose description reads `"TODO: describe this tool."` or `"Gets data."` passes today — while sitting in exactly the state CSDK-014 exists to prevent.

**The gap costs more on the TypeScript side than in Python, and CSDK-014's own explanation already says why:** there's no docstring fallback, so the `description` argument is the entire prompt-side account of the tool. In Python a thin docstring at least sits next to readable source; here the string *is* the interface.

CSDK-022 also names the mitigation people assume covers this: **the Zod input schema doesn't compensate.** It constrains the shape of the arguments once the model has decided to call this tool, and says nothing about whether calling it was the right move. Schema validation passing and the run being wrong are compatible.

Both predicates confirmed working against TypeScript tools rather than assumed — `has_description_text` reads `ToolDef.Description`, which for TS is the explicit description argument.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 208 rule(s) valid under rule schema version 14
```

Fire (one tool described `"TODO: describe this tool."`, one `"Gets data."`): `CSDK-021, CSDK-022, CSDK-203`
Silent (full description naming when to prefer the neighboring tool): `CSDK-203`

(CSDK-203 is the pre-existing missing-CLAUDE.md repo rule.)

CSDK-022 pairs `description_length_lt: 40` with `has_docstring: true` so it doesn't double-report against CSDK-014 on an empty description, same as CSDK-018.

No new predicates, so no `schema_version` bump.