### PR TITLE
feat(mcp): add MCP-027, MCP-028 TypeScript description quality rules

### DIFF
--- a/mcp/tool_definition.yaml
+++ b/mcp/tool_definition.yaml
@@ -309,3 +309,67 @@ rules:
     fix: >
       Rename the method (or set the `#[tool]` `name = "..."` argument) to a
       verb-object form, e.g. `summarize_invoice`, `fetch_weather`.
+
+  - id: MCP-027
+    title: TypeScript MCP tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The tool registration sets a description, so it passes MCP-011, but the
+      string is a placeholder rather than real content. The server publishes it
+      across the protocol boundary in its tools/list response, so it is the
+      entire account of the tool that every connecting client and model
+      receives, and "TODO: describe this tool" tells them nothing the tool name
+      did not. The consumer has no fallback: it cannot read this repo's source,
+      the neighboring tools, or the project's docs. The server's authors do not
+      see the result either, because mis-selection surfaces in someone else's
+      client session as a wrong answer rather than as an error on this side of
+      the connection.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when a model should call it rather than a
+      neighboring tool on this server. Write it for a reader with no other
+      knowledge of the server, since that is what a connecting client is.
+
+  - id: MCP-028
+    title: TypeScript MCP tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. It is the whole of what the server publishes about the tool in
+      tools/list, so a stub like "Gets data." leaves scope and preconditions to
+      guesswork for every client that connects. The Zod input schema does not
+      close the gap — it constrains the arguments once the model has chosen this
+      tool, not whether choosing it was right. The ambiguity also is not
+      confined to this server: a client typically connects several at once and
+      the model picks across all of them from these strings alone, so a thin
+      description competes badly against a well-described tool from an unrelated
+      server that only approximately fits the request.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives. Name the domain the tool acts on rather than assuming the
+      server name conveys it, since the model sees the tool alongside those of
+      every other connected server.


### PR DESCRIPTION
The TypeScript counterpart to MCP-025/026 (#88). MCP-011 only checks that a description *exists*, so a registration described `"TODO: describe this tool."` or `"Gets data."` passes today while publishing no selection signal to connecting clients.

Carries the same protocol-boundary argument as the Python pair, which is what makes this more than a lint:

- **The consumer has no fallback context** — it can't read this repo's source, the neighboring tools, or the project's docs.
- **The server's authors never observe the mis-selection** — it surfaces in someone else's client session as a wrong answer, not as an error on this side.
- **The competition isn't just this server's tools** — a client typically connects several at once and the model picks across all of them from these strings alone.

Plus the TypeScript-specific point in MCP-028: **the Zod input schema doesn't close the gap.** It constrains the arguments once the model has chosen this tool, not whether choosing it was right.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 208 rule(s) valid under rule schema version 14
```

Fire (one `server.tool` described `"TODO: describe this tool."`, one `"Gets data."`): `MCP-027, MCP-028`
Silent (full description naming when to prefer the neighboring tool): no findings

MCP-028 pairs `description_length_lt: 40` with `has_docstring: true` so it doesn't double-report against MCP-011 on an empty description, same as CSDK-018.

No new predicates, so no `schema_version` bump.

**Merge note:** this and #88 both append to `mcp/tool_definition.yaml`, so whichever lands second will need a trivial rebase — the two rule blocks are independent and the resolution is "keep both." Ping me and I'll rebase, or take them in either order and I'll follow up. This is the only pair among my open PRs that touches the same file; the rest are all distinct files.