### PR TITLE
feat(mcp): add MCP-029, TypeScript tool writes to the filesystem

### DIFF
--- a/mcp/path_safety.yaml
+++ b/mcp/path_safety.yaml
@@ -37,3 +37,35 @@ rules:
     fix: >
       Resolve the path with `Path(...).resolve()` and assert it sits under an
       allowed root before any I/O touches it. Reject paths that escape the root.
+
+  - id: MCP-029
+    title: TypeScript MCP tool writes to the filesystem
+    severity: low
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_write_call: true
+    explanation: >
+      This TypeScript MCP tool handler writes to the filesystem. If the path or
+      the contents derive from the tool's arguments, the caller on the other
+      side of the protocol chooses both — and that caller is a model, steerable
+      by a prompt injection carried in retrieved content or an earlier tool
+      result. How the server is deployed makes this sharper than it looks: a
+      stdio server is launched as a subprocess by whatever client the user is
+      running, so it inherits that user's own filesystem permissions rather
+      than a service account's, and a write escaping its intended directory
+      reaches the user's home directory, dotfiles, and SSH keys. The server also
+      cannot see the injection — it receives a well-formed tools/call for a path
+      it has no way to distinguish from a legitimate one. (Coarse signal — it
+      flags any filesystem write, not only unnormalized paths, because
+      TypeScript path-normalization analysis is not yet wired. Confirm the path
+      is genuinely caller-supplied before acting.)
+    fix: >
+      Confine writes to a dedicated working directory: resolve the final path,
+      verify it stays under that root before writing, and reject absolute paths
+      and any input containing "..". Where the tool only ever writes generated
+      names, derive the filename server-side from an id rather than accepting a
+      path over the protocol at all.


### PR DESCRIPTION
MCP-005 covers the Python path-safety case; the TypeScript half was missing. Mirrors CSDK-012 — the TS half of the Claude SDK pair — including its coarse-signal caveat, stated in the explanation so the finding is honest about itself: it flags *any* filesystem write, not only unnormalized paths, because TS path-normalization analysis isn't wired yet. Confidence 0.5 to match.

**Deployment is what sharpens this for MCP**, and it's the part worth having in the finding text. A stdio server is launched as a subprocess by whatever client the user is running, so it inherits **that user's own filesystem permissions**, not a service account's. A write escaping its intended directory doesn't hit a sandbox — it reaches the user's home directory, dotfiles, and SSH keys.

The second half is that **the server cannot see the injection.** It receives a well-formed `tools/call` for a path it has no way to distinguish from a legitimate one, so there's no server-side signal to alert on. Containment has to be structural.

The fix names the stronger remedy for the common case: derive the filename server-side from an id rather than accepting a path over the protocol at all.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 207 rule(s) valid under rule schema version 14
```

Fire (`writeFileSync(notePath, body)` with `notePath` from the tool schema): `MCP-029`
Silent (server-derived id, no caller-supplied path): no findings

No new predicates, so no `schema_version` bump.