### PR TITLE
feat: add path-containment rules to the four packs that lacked them

### DIFF
--- a/autogen/path_safety.yaml
+++ b/autogen/path_safety.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: autogen_path_safety
+  name: AutoGen filesystem path safety
+  category: autogen
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside an
+    AutoGen / AG2 tool without containment. Tool arguments are produced by the
+    model from the shared conversation, so a traversal payload reaches real
+    filesystem state if the function does not resolve and gate it.
+
+rules:
+  - id: AG2-014
+    title: AutoGen tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      AutoGen fills the argument from the conversation, and in a group chat every
+      participant writes into that conversation, so a path proposed by any agent
+      — including one summarizing untrusted content — reaches this function. A
+      ../../etc/passwd then reads or writes state outside the intended directory.
+      Detection is heuristic: confirm the parameter is genuinely model-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      Do the check on the resolved path — validating the raw string still lets
+      symlinks and .. segments through.

--- a/crewai/path_safety.yaml
+++ b/crewai/path_safety.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: crewai_path_safety
+  name: CrewAI filesystem path safety
+  category: crewai
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside a
+    CrewAI tool without containment. Tool arguments come from the agent, and in
+    a crew they may originate in another agent's output, so a traversal payload
+    reaches real filesystem state if the handler does not resolve and gate it.
+
+rules:
+  - id: CREW-008
+    title: CrewAI tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      The argument is chosen by the agent from its context, and in a crew that
+      context includes other agents' task output and any document they fetched,
+      so the path is attacker-reachable through any of those. A ../../etc/passwd
+      then reads or writes state outside the intended directory. Detection is
+      heuristic: confirm the parameter is genuinely agent-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      Do the check on the resolved path — validating the raw string still lets
+      symlinks and .. segments through.

--- a/langchain/path_safety.yaml
+++ b/langchain/path_safety.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: langchain_path_safety
+  name: LangChain filesystem path safety
+  category: langchain
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside a
+    LangChain / LangGraph tool without containment. The tool's arguments are
+    produced by the model from conversation context, so a traversal payload
+    reaches real filesystem state if the handler does not resolve and gate it.
+
+rules:
+  - id: LC-008
+    title: LangChain tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      A LangChain tool's arguments are filled in by the model from whatever is in
+      its context — retrieved documents, tool output, user text — so the path is
+      attacker-reachable wherever any of that is untrusted, and a
+      ../../etc/passwd reads or writes state outside the intended directory.
+      Detection is heuristic: confirm the parameter is genuinely model-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      Do the check on the resolved path — validating the raw string still lets
+      symlinks and .. segments through.

--- a/pydantic_ai/path_safety.yaml
+++ b/pydantic_ai/path_safety.yaml
@@ -1,0 +1,43 @@
+policy:
+  id: pydantic_ai_path_safety
+  name: Pydantic AI filesystem path safety
+  category: pydantic_ai
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside a
+    Pydantic AI tool without containment. A validated argument type constrains
+    the shape of the path, not where it points, so a traversal payload reaches
+    real filesystem state if the tool does not resolve and gate it.
+
+rules:
+  - id: PYD-009
+    title: Pydantic AI tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      Pydantic AI validates the argument against its annotation, which is easy to
+      mistake for having validated it: str and Path both accept ../../etc/passwd,
+      because the type says what the value looks like and not where it points.
+      The model fills the argument from its context, so the path is
+      attacker-reachable wherever that context is. Detection is heuristic:
+      confirm the parameter is genuinely model-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      A Pydantic field validator is a good place for it, provided it checks the
+      resolved path — validating the raw string still lets symlinks and .. through.


### PR DESCRIPTION
> Paired with the engine PR on a branch of the **same name**, so `rules-sync` resolves this pack. Neither should merge alone.

## The gap

Four packs ship a rule for a caller-supplied path reaching filesystem I/O without being resolved and gated:

| pack | rule | severity |
|---|---|---|
| Claude Agent SDK | CSDK-004 | high |
| OpenAI Agents SDK | OAI-006 | high |
| Google ADK | ADK-004 | high |
| MCP | MCP-005 | high |

LangChain, CrewAI, AutoGen and Pydantic AI ship none. This is the **highest-severity** gap in those packs — a path-traversal check simply absent from four of the five listed as weakest coverage. They already have `shell_safety`, `code_execution` and `ssrf`; filesystem containment was the missing member of that set.

Adds **LC-008, CREW-008, AG2-014, PYD-009**, reusing `call_uses_unnormalized_path_param` with the same callee set (`open`, `Path`, `shutil.*`, `os.*`) at the same `high` / `0.7`.

## Why the text is per-SDK

The predicate is shared; what makes the argument *attacker-controlled* is not. Each rule names its own reachability path:

- **LangChain** — the model fills the argument from its context: retrieved documents, tool output, user text.
- **CrewAI** — that context includes other agents' task output, so the path can originate in an agent that summarized an untrusted document.
- **AutoGen** — the argument comes from the shared conversation, which in a group chat *every* participant writes to.
- **Pydantic AI** — worth stating explicitly, because the framework invites the mistake: the argument **is** validated, against its annotation. But `str` and `Path` both accept `../../etc/passwd`. The type constrains what the value looks like, not where it points.

## Verified end to end

Built the engine and scanned real sample projects with `--rules-repo` pointed at this branch:

```
LC-008   [high] read_doc    tools.py:8
CREW-008 [high] read_doc    tools.py:8
AG2-014  [high] read_notes  tools.py:8
PYD-009  [high] read_ledger tools.py:9
```

Each sample also contains a second tool that does `Path(path).resolve()` plus an `is_relative_to(ROOT)` check. None of the rules fired on it — including the per-param behavior the predicate comment documents.

## IDs

`LC-008`, `CREW-008`, `AG2-014`, `PYD-009` — all previously unused.