### PR TITLE
feat(langchain): add LC-009, tool network call has no timeout

### DIFF
--- a/langchain/network.yaml
+++ b/langchain/network.yaml
@@ -1,0 +1,57 @@
+policy:
+  id: langchain_network
+  name: LangChain tool network hygiene
+  category: langchain
+  description: >
+    Network-call hygiene inside LangChain tool functions. A tool that makes a
+    network request without a timeout can hang the agent run indefinitely.
+
+rules:
+  - id: LC-009
+    title: LangChain tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - requests.Session.get
+          - requests.Session.post
+          - urllib.request.urlopen
+          # Bare `urlopen` covers the from-import form.
+          - urlopen
+          # Aliased aiohttp sessions canonicalize to aiohttp.ClientSession.<m>.
+          - aiohttp.ClientSession.get
+          - aiohttp.ClientSession.post
+        missing: timeout
+    explanation: >
+      This LangChain tool makes a network request with no timeout, so it hangs
+      indefinitely on a slow or unresponsive remote. The call runs inside the
+      agent's step, so the whole executor blocks on it — max_iterations bounds how
+      many steps an agent takes, not how long one step lasts, and no LangChain
+      setting caps the duration of a tool call. The agent therefore has no bound
+      at all on that path: it does not fail, retry, or surface anything to the
+      model; it simply stops, holding whatever runtime is hosting it until the
+      connection eventually dies.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough for a legitimately slow endpoint, and
+      return the timeout to the model as a structured, retryable error so it can
+      react rather than waiting on a call that will never return.


### PR DESCRIPTION
> Paired with the engine PR on a branch of the **same name**, so `rules-sync` resolves this pack. Neither should merge alone.

## The gap

Every other pack has a no-timeout rule. LangChain does not:

| pack | rule | | pack | rule |
|---|---|---|---|---|
| Claude Agent SDK | CSDK-003 | | AutoGen | AG2-012 |
| OpenAI Agents SDK | OAI-005 | | Pydantic AI | PYD-006 |
| Google ADK | ADK-003 | | Vercel AI | VAI-011 |
| MCP | MCP-004 | | **LangChain** | **— none —** |

`LC-009` uses the same `call_without_kwarg` predicate and the same 20-callee set as PYD-006, at the same `high` / `0.85`.

## Why it matters specifically here

LangChain has an iteration bound and no time bound. `max_iterations` caps how many steps an agent takes, **not how long one step lasts**, and no LangChain setting caps the duration of a tool call.

So a hung request is not a slow path — it is an unbounded one. The executor blocks inside the step: nothing fails, nothing retries, and the model is never told. The agent simply stops, holding whatever runtime hosts it until the connection eventually dies. That is a worse outcome than the same defect in a plain script, where at least the caller can see it hang.

## Verified end to end

Built the engine and scanned a sample with `--rules-repo` pointed at this branch:

```
LC-009 [high] fetch_status tools.py:6
```

The sample's second tool is the identical request with `timeout=10`; the rule did not fire on it.