### PR TITLE
feat(crewai): add CREW-009, tool network call has no timeout

### DIFF
--- a/crewai/network.yaml
+++ b/crewai/network.yaml
@@ -1,0 +1,56 @@
+policy:
+  id: crewai_network
+  name: CrewAI tool network hygiene
+  category: crewai
+  description: >
+    Network-call hygiene inside CrewAI tool functions. A tool that makes a
+    network request without a timeout can hang the agent run indefinitely.
+
+rules:
+  - id: CREW-009
+    title: CrewAI tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - requests.Session.get
+          - requests.Session.post
+          - urllib.request.urlopen
+          # Bare `urlopen` covers the from-import form.
+          - urlopen
+          # Aliased aiohttp sessions canonicalize to aiohttp.ClientSession.<m>.
+          - aiohttp.ClientSession.get
+          - aiohttp.ClientSession.post
+        missing: timeout
+    explanation: >
+      This CrewAI tool makes a network request with no timeout, so it hangs
+      indefinitely on a slow or unresponsive remote. The call runs inside the
+      agent's step, and max_iter bounds how many steps an agent takes rather than
+      how long one lasts, so nothing in the crew caps it. In a sequential process
+      the stall also blocks every task queued behind this one: a single
+      unresponsive endpoint stops the whole crew, not just the agent that called
+      it, and no result is produced for any of them.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough for a legitimately slow endpoint, and
+      return the timeout to the model as a structured, retryable error so the
+      agent can react rather than waiting on a call that will never return.


### PR DESCRIPTION
> Paired with the engine PR on a branch of the **same name**, so `rules-sync` resolves this pack. Neither should merge alone.

## The gap

Every other pack has a no-timeout rule. CrewAI does not:

| pack | rule | | pack | rule |
|---|---|---|---|---|
| Claude Agent SDK | CSDK-003 | | AutoGen | AG2-012 |
| OpenAI Agents SDK | OAI-005 | | Pydantic AI | PYD-006 |
| Google ADK | ADK-003 | | Vercel AI | VAI-011 |
| MCP | MCP-004 | | **CrewAI** | **— none —** |

`CREW-009` uses the same `call_without_kwarg` predicate and the same 20-callee set as PYD-006, at the same `high` / `0.85`.

## Why it matters specifically here

CrewAI bounds iterations, not time. `max_iter` caps how many steps an agent takes; nothing caps how long one takes, so a hung request is an unbounded path rather than a slow one.

The crew structure makes it worse than the single-agent case. In a sequential process, tasks run in order — so a stall inside one agent's tool call **blocks every task queued behind it**. One unresponsive endpoint stops the whole crew, and none of the downstream tasks produce a result either. The blast radius of a missing `timeout=` is the run, not the call.

## Verified end to end

Built the engine and scanned a sample with `--rules-repo` pointed at this branch:

```
CREW-009 [high] fetch_quote tools.py:6
```

The sample's second tool is the identical request with `timeout=10`; the rule did not fire on it.