### PR TITLE
feat(autogen): add AG2-015, mutating tool has no idempotency key

### DIFF
--- a/autogen/idempotency.yaml
+++ b/autogen/idempotency.yaml
@@ -1,0 +1,55 @@
+policy:
+  id: autogen_idempotency
+  name: AutoGen mutating-tool idempotency
+  category: autogen
+  description: >
+    Rules that flag mutating tools (create/send/refund/...) without an
+    idempotency key. Retries (model re-invocation, a group-chat speaker
+    re-issuing a call, or your own retry policy) can re-run a side-effecting
+    call; without a key the same action can fire twice.
+
+rules:
+  - id: AG2-015
+    title: Mutating AutoGen tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). A mutating tool
+      with no idempotency key cannot tell a new request from a retry of one whose
+      result was lost, and AutoGen supplies more ways for that retry to happen
+      than a single-agent loop does. The tool response is a message in a
+      conversation that is re-sent in full on every later turn, so a call whose
+      result read as inconclusive stays visible and re-invitable for the rest of
+      the run; in a group chat any speaker the manager selects can re-issue it,
+      including an agent that was not the original caller and cannot know the
+      side effect already committed. Without a key the same action fires twice —
+      a duplicate charge, a double-sent message, a repeated delete. Downstream
+      services must also honor the key for this protection to be effective.
+    fix: >
+      Add an `idempotency_key: str` parameter and pass it through to the backing
+      API so a retried call is recognized and deduplicated rather than
+      re-executed. Derive the key from the request's own identity, not from a
+      fresh uuid4() per call — a key regenerated on the retry deduplicates
+      nothing.


### PR DESCRIPTION
> Paired with the engine PR on a branch of the **same name**, so `rules-sync` resolves this pack. Neither should merge alone.

## The gap

Six packs ship an idempotency rule. AutoGen does not:

| pack | rule | | pack | rule |
|---|---|---|---|---|
| Claude Agent SDK | CSDK-006 / CSDK-016 | | MCP | MCP-007 |
| OpenAI Agents SDK | OAI-009 / OAI-019 | | CrewAI | CREW-006 |
| Google ADK | ADK-006 | | Pydantic AI | PYD-007 |
| | | | **AutoGen** | **— none —** |

`AG2-015` uses the same `name_has_prefix` + `param_name_matches` predicate pair as CREW-006, at the same `medium` / `0.55`.

## Why it matters specifically here

The generic argument is that retries re-run side effects. AutoGen supplies **more ways for the retry to happen** than a single-agent loop does, and both come from its conversation model:

- The tool response is a message in a conversation that is **re-sent in full on every later turn**. A call whose result read as inconclusive does not scroll away — it stays visible and re-invitable for the rest of the run.
- In a `GroupChat`, **any speaker the manager selects can re-issue it** — including an agent that was not the original caller, and therefore cannot know the side effect already committed.

So the window in which a duplicate `refund_payment` can fire is the whole run, and the agent that fires it may be one with no memory of the first attempt.

## The fix text names the non-fix

Worth flagging, because it is the common way this gets "fixed" wrongly:

> Derive the key from the request's own identity, not from a fresh `uuid4()` per call — a key regenerated on the retry deduplicates nothing.

A parameter named `idempotency_key` filled with a fresh UUID at each call satisfies the *rule* while providing no deduplication at all. The rule cannot see this; the text says so.

## Verified end to end

```
AG2-015 [medium] refund_payment tools.py:6
```

The sample's second tool is the same `refund_payment` with an `idempotency_key` parameter threaded through to the backing call; the rule did not fire on it.