### PR TITLE
feat(crewai): add CREW-013, ambiguous tool name

### DIFF
--- a/crewai/tool_definition.yaml
+++ b/crewai/tool_definition.yaml
@@ -52,3 +52,34 @@ rules:
       Annotate every parameter with a concrete type (str, int, list[str], a
       Pydantic model, etc.). CrewAI propagates these annotations into the schema the
       model sees, so the model emits correctly-shaped arguments.
+
+  - id: CREW-013
+    title: Ambiguous CrewAI tool name
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - go
+        - thing
+        - stuff
+    explanation: >
+      The tool name is a generic verb that says nothing about what the tool
+      acts on. The name sits directly beside the description in what the model
+      sees, so it is half the selection signal, and a name like process or
+      handle spends that half on nothing — the model either calls the tool for
+      the wrong job or passes over it entirely. In a crew the wrong pick does not stay local: the task output it produces is threaded forward as context to every task behind it, and CREW-104 delegation means peers select from the same name.
+    fix: >
+      Rename to a verb-object form that names the thing acted on:
+      summarize_invoice, refund_charge, fetch_order_status. Keep the
+      description for the detail and let the name carry the subject.


### PR DESCRIPTION
Ports the ambiguous-name check to CrewAI. Claude SDK (CSDK-007), OpenAI (OAI-007), ADK (ADK-007), and MCP (MCP-003) all ship it; the newer packs had none.

The tool name sits directly beside the description in what the model sees, so **it is half the selection signal** — and a generic verb like `process` or `handle` spends that half on nothing. In a crew the wrong pick does not stay local: the task output it produces is threaded forward as context to every task behind it, and CREW-104 delegation means peers select from the same name.

Same `name_in` list as CSDK-007, so behavior stays consistent across packs.

**Verification** — engine built at `main`:

```
$ trustabl rules validate .
OK: 85 rule pack(s), 211 rule(s) valid under rule schema version 14
```

Fire (tool named `process`): includes `CREW-013`
Silent (same tool renamed `summarize_invoice`): `CREW-013` absent

**A note on scope.** I drafted a fifth rule in this batch for the Vercel AI SDK and dropped it after testing: `ToolDef.Name` is deliberately empty for `vercel_ai_tool`, because the SDK derives a tool's name from the key in the `tools: { ... }` record rather than from the `tool({...})` call. The engine asserts this directly —

```go
// internal/analysis/ts_vercel_tools_test.go
if tl.Name != "" {
    t.Errorf("Name: got %q, want empty (Vercel derives name from the tools-record key)", tl.Name)
}
```

so **every name-based predicate (`name_in`, `name_has_prefix`) is structurally inert for that pack** — it also blocks a Vercel idempotency rule, which is why the pack has none. Back-filling `Name` from the record key at discovery time would unblock both. Happy to open that engine PR if it'd be useful.

Paired engine PR follows, mirroring the rule into `testdata/rules-fixture/` with fire/silent cases.