### PR TITLE
feat(vercel_ai): add VAI-010 mutating tool idempotency rule

### DIFF
--- a/vercel_ai/idempotency.yaml
+++ b/vercel_ai/idempotency.yaml
@@ -1,0 +1,56 @@
+policy:
+  id: vercel_ai_idempotency
+  name: Vercel AI SDK mutating-tool idempotency
+  category: vercel_ai
+  description: >
+    Rules that flag mutating Vercel AI SDK tools without an idempotency key.
+    Agents retry tool calls under timeouts and ambiguous failures; without a
+    key the same side-effecting action can fire more than once. Vercel tools
+    leave ToolDef.Name empty (the model-facing name is the agent's tools-record
+    key), so matching uses the binding identifier (VarName) via name_has_prefix.
+
+rules:
+  - id: VAI-010
+    title: TypeScript mutating Vercel AI tool has no idempotency key
+    severity: medium
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create
+            - send
+            - delete
+            - post
+            - update
+            - refund
+            - charge
+            - issue
+        - not:
+            has_body_text:
+              - idempot
+              - request_id
+              - requestId
+              - txn_id
+              - txnId
+              - correlation_id
+              - correlationId
+    explanation: >
+      A Vercel AI SDK tool whose binding name implies a side effect
+      (create/send/delete/refund/…) has no idempotency token visible in its
+      definition. The SDK does not retry tool calls for you by default, but
+      retries still happen — the model re-invokes the tool when a result reads
+      as inconclusive, and an orchestrator, your own retry policy, or a lost
+      response (at-least-once delivery) can re-issue the call; without a key
+      threaded through to the backing API the same action fires twice. Prefixes
+      are underscore-free so both `create_charge` and `createCharge` bindings
+      match. Detection keys off VarName because Vercel leaves ToolDef.Name empty.
+    fix: >
+      Add an `idempotencyKey: z.string()` field to the tool's inputSchema and
+      forward it to the underlying API (Stripe `Idempotency-Key` header,
+      REST `X-Request-ID`, GraphQL `clientMutationId`, etc.). If the backing
+      service does not honor idempotency keys, document the gap and dedupe in
+      your own store keyed by the token before issuing the call.


### PR DESCRIPTION
## Summary
- Add `vercel_ai/idempotency.yaml` with **VAI-010**: TypeScript mutating Vercel AI tools (`create`/`send`/`charge`/…) with no idempotency marker in the tool definition.
- Vercel leaves `ToolDef.Name` empty (model-facing name is the agent's tools-record key), so matching relies on `VarName` via `name_has_prefix` — pairs with the engine PR that falls back to `VarName` when `Name` is empty.

## Stack
1. Engine: VarName fallback + fixture + fire/silent cases
2. **This PR** — rule YAML
3. Rulebook: rationale doc

## Test plan
- [ ] Engine CI green with paired engine branch (or merge engine first)
- [ ] `trustabl rules validate` over the packs
- [ ] Confirm no ID collision with open VAI-013..015 PRs

Made with [Cursor](https://cursor.com)