### PR TITLE
feat(langchain): detect Requests calls without timeout

### DIFF
--- a/langchain/network.yaml
+++ b/langchain/network.yaml
@@ -1,0 +1,43 @@
+policy:
+  id: langchain_network
+  name: LangChain tool network hygiene
+  category: langchain
+  description: >
+    Network-call hygiene inside LangChain tool functions. A tool that makes a
+    Requests HTTP call without a finite timeout can remain blocked when an
+    upstream service fails to respond, stalling the agent tool invocation.
+
+rules:
+  - id: LC-007
+    title: LangChain tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - requests.Session.get
+          - requests.Session.post
+        missing: timeout
+    explanation: >
+      This LangChain tool performs a Requests HTTP call without a finite
+      timeout, so it can remain blocked when an upstream service or network
+      fails to respond. The tool invocation cannot complete while the request
+      waits, which consumes worker and runtime resources and prevents the
+      agent step from finishing. A kwarg present with literal None counts as
+      missing.
+    fix: >
+      Configure an explicit finite Requests timeout appropriate to the
+      upstream service's latency and SLA, and handle timeout failures as a
+      structured tool error the model can react to rather than letting the
+      call remain blocked.


### PR DESCRIPTION
## Summary

Adds `LC-007` to detect Python `requests` calls without a finite timeout inside LangChain tools.

LangChain Python currently lacks equivalent timeout coverage while similar network-timeout rules exist for other supported SDKs. This adds that coverage using Trustabl''s existing `call_without_kwarg` predicate without requiring engine or schema changes.

## Detection

`LC-007` fires for supported `requests` calls inside LangChain tools when:

- `timeout` is omitted
- `timeout=None`

It remains silent when an explicit finite timeout is supplied.

The rule intentionally does **not** flag `httpx` merely because a call omits an explicit `timeout`, since HTTPX provides default timeout behavior.

## Scope

This contribution is intentionally limited to Python Requests call-site detection.

Known limitations include wrapper functions, dynamically configured client defaults, positional timeout handling, and HTTP libraries outside the current Requests-specific scope.

## Validation

- Existing `call_without_kwarg` predicate reused
- No production engine changes
- No schema changes
- No manifest changes
- Canonical rule mirrored byte-for-byte in the companion engine fixture
- `git diff --check` passes

## Companion PRs

- Engine fixture/tests: https://github.com/trustabl/trustabl/pull/191
- Rulebook rationale: https://github.com/trustabl/trustabl-rulebook/pull/107