### PR TITLE
ci: generate the rule-count badge instead of hardcoding it

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,11 @@ on:
 env:
   CGO_ENABLED: "1"
 
+# contents: write is only exercised on a push to main, to refresh the generated
+# rule-count badge. PR runs never write.
+permissions:
+  contents: write
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -61,5 +66,34 @@ jobs:
         run: go build -o "$RUNNER_TEMP/trustabl" ./cmd/trustabl
 
       - name: Validate rule packs
+        id: validate
         run: |
-          "$RUNNER_TEMP/trustabl" rules validate ./rules
+          out="$("$RUNNER_TEMP/trustabl" rules validate ./rules)"
+          echo "$out"
+          count=$(printf '%s' "$out" | sed -n 's/.*, \([0-9][0-9]*\) rule(s) valid.*/\1/p')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      # The rule count used to be hardcoded in three places and disagreed with
+      # reality in all three (206 badge / 206 prose / 185+ prose, actual 204).
+      # Generate it from the validator's own output so there is one source and
+      # it cannot go stale; shields.io reads it as an endpoint badge.
+      - name: Refresh the rule-count badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: rules
+        run: |
+          n='${{ steps.validate.outputs.count }}'
+          [ -n "$n" ] || { echo "::error::no rule count parsed from validator"; exit 1; }
+          mkdir -p badges
+          printf '{"schemaVersion":1,"label":"rules","message":"%s","color":"brightgreen"}\n' "$n" \
+            > badges/rules.json
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add badges/rules.json
+          if git diff --staged --quiet; then
+            echo "rule count unchanged at $n"
+          else
+            git commit -m "chore(badges): rule count -> $n"
+            # ponytail: non-fatal. If main is branch-protected the badge keeps
+            # its last value instead of reddening every push to main.
+            git push || echo "::warning::badge refresh could not push (protected main?)"
+          fi

--- a/badges/rules.json
+++ b/badges/rules.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"rules","message":"204","color":"brightgreen"}


### PR DESCRIPTION
Punchlist item 56. The count lived in three hardcoded places in the engine README and none of them matched the 204 rules actually shipped here.

validate.yml already builds the engine and runs "rules validate" on every push and PR, and that command prints the authoritative count. Parse it, write a shields.io endpoint file, and commit it when it changes — push events on main only, so PR runs never write.

The push is deliberately non-fatal: if main is branch-protected the badge keeps its last value rather than reddening every push to main.

badges/rules.json is seeded at the current 204 so the badge resolves before the first workflow run.