### PR TITLE
feat(claude_sdk): add CSDK-205, permissive mode with no deny-list

### DIFF
--- a/claude_sdk/repo.yaml
+++ b/claude_sdk/repo.yaml
@@ -84,3 +84,35 @@ rules:
       surface and handle rather than to raise it: if a task legitimately
       needs many turns, split it into bounded sub-sessions instead of
       removing the bound.
+
+  - id: CSDK-205
+    title: Claude Agent SDK session auto-approves edits with no tool deny-list
+    severity: medium
+    confidence: 0.7
+    applies_to:
+      - claude_sdk
+    scope: repo
+    match:
+      all:
+        - repo_claude_options_permission_mode_is:
+            - acceptEdits
+        - repo_claude_options_disallowed_tools_missing: true
+    explanation: >
+      A ClaudeAgentOptions(...) in this project sets permission_mode to
+      "acceptEdits", which auto-approves file writes and edits without a
+      prompt, and no construction in the project sets disallowed_tools. Claude
+      SDK's allowed_tools only auto-approves listed tools — it does not
+      restrict which tools can run, so an unlisted tool still executes,
+      falling back to whatever the current permission_mode allows. With
+      acceptEdits already removing the approval step for Write/Edit and no
+      deny-list to bound the rest of the tool surface, a prompt-injected or
+      mistaken model action can reach shell commands, network fetches, or any
+      other tool the session can see, with nothing short of a human noticing
+      to stop it.
+    fix: >
+      Pass disallowed_tools= to ClaudeAgentOptions(...), naming the tools this
+      session must never call — at minimum shell execution and any tool that
+      reaches the network or credentials. Keep acceptEdits if auto-approving
+      file edits is intentional, but pair it with an explicit deny-list so the
+      rest of the tool surface stays gated, or drop back to permission_mode
+      "default" if edits should prompt too.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 14
+schema_version: 15


### PR DESCRIPTION
Closes the Claude SDK half of Class 1 tool access-control scoping. Claude SDK's allowed_tools only auto-approves, it never restricts — so the risk signal is a permissive permission_mode (acceptEdits) paired with a missing disallowed_tools deny-list, not an empty allow-list.

acceptEdits chosen over bypassPermissions deliberately — CSDK-202 already fires standalone on bypassPermissions; including it here would double-report every tripping repo.

Mirrored byte-for-byte from the engine fixture (verified via diff, no output). Schema version bumped to 15.