### PR TITLE
feat(download-history): badge counts from a fresh baseline

### DIFF
--- a/.github/stats/download-history.json
+++ b/.github/stats/download-history.json
@@ -1,18 +1,18 @@
 {
   "repo": "trustabl/trustabl-rules",
   "unit": "cumulative_release_downloads",
-  "baseline_date": "2026-09-04",
   "history": [
     {
       "date": "2026-09-04",
-      "bundles": 536,
-      "statements": 15,
+      "bundles": 539,
+      "statements": 17,
       "other": 0,
-      "total": 551,
+      "total": 556,
       "since_baseline": {
         "bundles": 0,
         "total": 0
       }
     }
-  ]
+  ],
+  "baseline_date": "2026-09-04"
 }

--- a/.github/workflows/download-history.yml
+++ b/.github/workflows/download-history.yml
@@ -127,14 +127,24 @@ jobs:
               json.dump(data, f, indent=2); f.write("\n")
 
           # Shields endpoint for the README badge, derived from the newest point so
-          # the badge and the series can never disagree. Reads bundles, not total:
-          # statement.json is cache-expiry noise and would inflate the headline.
+          # the badge and the series can never disagree.
+          #
+          # Shows the delta since the baseline, NOT the cumulative total. The
+          # cumulative figure includes pulls predating this tracker and cannot be
+          # reset (download_count is server-side and read-only), so the delta is
+          # the only number that answers "how much is it used now".
+          #
+          # Reads bundles, not total: statement.json is cache-expiry noise and
+          # moves by more than one per pull, so it would inflate the headline.
           latest = series[-1]
+          delta  = latest["since_baseline"]["bundles"]
+          bd     = datetime.date.fromisoformat(base["date"])
+          pretty = "%d %s %d" % (bd.day, bd.strftime("%b"), bd.year)
           os.makedirs(os.path.dirname(badge), exist_ok=True)
           with open(badge, "w") as f:
               json.dump({"schemaVersion": 1,
-                         "label": "rule downloads",
-                         "message": str(latest["bundles"]),
+                         "label": "downloads",
+                         "message": "+%d since %s" % (delta, pretty),
                          "color": "brightgreen"}, f)
               f.write("\n")
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/trustabl/trustabl-rules/releases"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrustabl%2Ftrustabl-rules%2Fmain%2Fbadges%2Frules.json" alt="Detection rule count"></a>
-  <a href="https://github.com/trustabl/trustabl-rules/releases"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrustabl%2Ftrustabl-rules%2Fmain%2Fbadges%2Fdownloads.json" alt="Rule bundle downloads"></a>
+  <a href="https://github.com/trustabl/trustabl-rules/releases"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrustabl%2Ftrustabl-rules%2Fmain%2Fbadges%2Fdownloads.json" alt="Rule bundle downloads since tracking began"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="Apache-2.0"></a>
 </p>
 

--- a/badges/downloads.json
+++ b/badges/downloads.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "rule downloads", "message": "536", "color": "brightgreen"}
+{"schemaVersion": 1, "label": "downloads", "message": "+0 since 4 Sep 2026", "color": "brightgreen"}


### PR DESCRIPTION
The badge showed the cumulative download_count, which carries pulls made long before this tracker existed and cannot be zeroed - download_count is server-side and read-only, and the only way to reset it is deleting and re-uploading the release assets, which would break rule resolution for every client pinned to those digests.

Show the delta since the baseline instead. The series already carried since_baseline; only the badge was reading the wrong field.

Baseline reset to today so the count starts from zero. The previous baseline was taken earlier the same day and had four pulls of test traffic on top of it.

Badge now reads: downloads | +0 since 4 Sep 2026