### PR TITLE
Reconcile the rule packs with the engine fixture: package, slash command, NAT and runtime packs at schema 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ claude_sdk/                           Claude Agent SDK rules (CSDK-NNN)
 ├── idempotency.yaml                  CSDK-006 (python), CSDK-016 (typescript)
 ├── network.yaml                      CSDK-003
 ├── path_safety.yaml                  CSDK-004 (python), CSDK-012 (typescript fs-write)
-├── repo.yaml                         CSDK-201, CSDK-202 (repo scope, permission bypass)
+├── repo.yaml                         CSDK-201..202, CSDK-204..206 (repo scope: permission bypass, unrestricted shell, pre-approved tools, max_turns)
 ├── repo_hygiene.yaml                 CSDK-203 (repo scope, CLAUDE.md missing)
 ├── shell_safety.yaml                 CSDK-108 (python), CSDK-010 (typescript)
 ├── ssrf.yaml                         CSDK-009 (python), CSDK-013 (typescript)

--- a/claude_sdk/agent_safety.yaml
+++ b/claude_sdk/agent_safety.yaml
@@ -63,7 +63,7 @@ rules:
 
   - id: CSDK-103
     title: AgentDefinition sets permissionMode to bypassPermissions
-    severity: high
+    severity: critical
     confidence: 0.9
     language: python
     applies_to:
@@ -145,7 +145,7 @@ rules:
 
   - id: CSDK-120
     title: TypeScript AgentDefinition sets permissionMode to bypassPermissions
-    severity: high
+    severity: critical
     confidence: 0.9
     language: typescript
     applies_to:

--- a/claude_sdk/repo.yaml
+++ b/claude_sdk/repo.yaml
@@ -10,7 +10,7 @@ policy:
 rules:
   - id: CSDK-201
     title: Project default permission mode bypasses approvals
-    severity: high
+    severity: critical
     confidence: 0.9
     applies_to:
       - claude_sdk
@@ -35,7 +35,7 @@ rules:
 
   - id: CSDK-202
     title: Session permission mode bypasses approvals
-    severity: high
+    severity: critical
     confidence: 0.9
     applies_to:
       - claude_sdk
@@ -59,6 +59,68 @@ rules:
       on a developer's or user's machine.
 
   - id: CSDK-204
+    title: Project settings pre-approve unrestricted shell
+    severity: critical
+    confidence: 0.9
+    applies_to:
+      - claude_sdk
+    scope: repo
+    match:
+      repo_claude_permission_allows_unrestricted_shell: true
+    explanation: >
+      A .claude/settings.json (or settings.local.json) in this repository lists
+      `Bash` in `permissions.allow` with no command pattern narrowing it, so
+      every shell command the model chooses runs without an approval prompt, in
+      every session, for the whole project. This is a wider grant than the same
+      string in one SKILL.md or one slash command: those apply while that skill
+      or command runs, this applies always. It reaches the same end state as
+      defaultMode "bypassPermissions" (CSDK-201) for the one tool that matters
+      most, without looking like a bypass in review.
+      Deny entries narrow this but do not replace it. Claude Code resolves deny
+      over allow, so a blanket allow with specific denies is "everything except
+      a blocklist", and a blocklist of dangerous shell commands is not
+      enumerable — the next unsafe invocation is always one the list did not
+      anticipate.
+    fix: >
+      Replace the blanket grant with the specific commands the project needs,
+      using the pattern form: "Bash(git status:*)", "Bash(npm test:*)". If
+      broader shell access is genuinely required, leave Bash out of
+      `permissions.allow` so each call prompts, and gate it with a PreToolUse
+      hook that allowlists commands. Keep unrestricted grants to disposable
+      sandboxes.
+
+  - id: CSDK-205
+    title: Project settings pre-approve side-effecting tools
+    severity: high
+    confidence: 0.8
+    applies_to:
+      - claude_sdk
+    scope: repo
+    match:
+      repo_claude_permission_allows_tool:
+        - Write
+        - Edit
+        - MultiEdit
+        - NotebookEdit
+        - WebFetch
+        - WebSearch
+    explanation: >
+      A .claude/settings.json in this repository pre-approves a tool that
+      changes state or reaches the network — a filesystem write, or web
+      retrieval — in `permissions.allow`, so it runs project-wide with no
+      prompt. Writes turn model-generated text into persistent state: source,
+      configuration, or the .claude/settings.json governing the agent's own
+      permissions. Web retrieval pulls attacker-reachable content into the
+      context and carries in-context data out in the request. Pre-approving
+      either removes the one human checkpoint on that class of action for every
+      session in the project.
+    fix: >
+      Remove these tools from `permissions.allow` and let them prompt, or scope
+      them with patterns so the grant covers only the paths and hosts the work
+      needs (e.g. "Write(src/generated/**)"). Prefer `ask` over `allow` for
+      anything that writes or fetches: it keeps the workflow while preserving
+      the checkpoint.
+  - id: CSDK-206
     title: Claude Agent SDK session sets no explicit max_turns limit
     severity: low
     confidence: 0.6

--- a/claude_sdk/subagent_safety.yaml
+++ b/claude_sdk/subagent_safety.yaml
@@ -76,3 +76,32 @@ rules:
       genuinely research-oriented. If the subagent must search, keep its other
       grants read-only so injected search content cannot escalate into writes
       or shell, and treat its output as untrusted in the parent loop.
+  - id: CSDK-113
+    title: Subagent frontmatter bypasses permission prompts
+    severity: critical
+    confidence: 0.9
+    applies_to:
+      - claude_subagent
+    scope: subagent
+    match:
+      subagent_permission_mode_is:
+        - bypassPermissions
+    explanation: >
+      This subagent's frontmatter sets `permissionMode: bypassPermissions`, so
+      every tool it is granted runs without an approval prompt for the whole
+      time it is dispatched. The grant list stops being a list of things the
+      subagent may ask to do and becomes a list of things it will do
+      unsupervised.
+      This is the same posture CSDK-201 flags for the project and CSDK-202 for
+      the session, on the surface where it is hardest to notice. A subagent is
+      dispatched autonomously by a lead agent in response to a model-generated
+      task description; nobody reads this file at dispatch time, and a prompt
+      injection that reaches the lead agent reaches the subagent's tools with the
+      approval gate already removed.
+    fix: >
+      Remove `permissionMode` from the frontmatter so the subagent inherits the
+      session's mode and its tool calls prompt, or set it to "default". If the
+      subagent genuinely must run unattended, narrow its `tools:` list to the
+      minimum the job needs and gate the dangerous ones with a PreToolUse hook —
+      an unattended subagent with a wide grant list is the combination this rule
+      exists to prevent.

--- a/claude_skill/slash_command_safety.yaml
+++ b/claude_skill/slash_command_safety.yaml
@@ -1,0 +1,96 @@
+policy:
+  id: claude_slash_command_safety
+  name: Claude Code slash command safety
+  category: claude_skill
+  description: >
+    Capability handed over by a Claude Code slash command (.claude/commands/*.md).
+    A command's allowed-tools frontmatter is a pre-approved tool list, exactly as
+    a SKILL.md's is, and until the slash_command scope existed nothing could read
+    it: the same `allowed-tools: Bash` was a critical finding in a skill and no
+    finding at all in a command. Slash command rules audit frontmatter only and
+    are language-agnostic (markdown), so they carry no language: field.
+
+rules:
+  - id: CCMD-001
+    title: Slash command auto-approves unrestricted shell
+    severity: critical
+    confidence: 0.9
+    applies_to:
+      - claude_slash_command
+    scope: slash_command
+    match:
+      slash_command_allows_unrestricted_shell: true
+    explanation: >
+      This slash command's `allowed-tools` grants `Bash` with no command pattern
+      narrowing it, so every shell command the model chooses while the command
+      runs is pre-approved and executes without an approval prompt. The grant is
+      the whole gate: Claude Code asks the user before running a shell command
+      precisely because the command text is model-generated, and listing a bare
+      `Bash` removes that question for the lifetime of the invocation. Anything
+      that can steer the model during the command — a fetched page, a file it
+      reads, an issue body pasted into the prompt — reaches the shell with no
+      human in the loop. This is the same exposure CSKILL-001 flags on a
+      SKILL.md, on a surface that had no rules at all.
+    fix: >
+      Scope the grant to the commands the task actually needs, using the pattern
+      form: `allowed-tools: Bash(git status:*), Bash(npm test:*)`. If the command
+      genuinely needs open shell access, remove `Bash` from `allowed-tools` and
+      let the normal approval prompt run, or gate it with a PreToolUse hook that
+      allowlists specific commands.
+
+  - id: CCMD-002
+    title: Model-invocable slash command grants file-writing tools
+    severity: high
+    confidence: 0.8
+    applies_to:
+      - claude_slash_command
+    scope: slash_command
+    match:
+      all:
+        - slash_command_model_invocable: true
+        - slash_command_allows_tool:
+            - Write
+            - Edit
+            - MultiEdit
+            - NotebookEdit
+    explanation: >
+      This slash command grants a filesystem-write built-in and does not set
+      `disable-model-invocation: true`, so the model can invoke it on its own
+      rather than only when a human types it. That combination is what turns a
+      tool grant into an injection surface: the command is reachable from any
+      text that reaches the model, and it arrives carrying pre-approved write
+      access. A prompt injection does not need to talk the model into a risky
+      edit, only into running a command that already has permission to make one.
+      Writes are also persistent — source, configuration, or the
+      .claude/settings.json governing the agent's own permissions.
+    fix: >
+      Set `disable-model-invocation: true` so the command runs only when a human
+      types it, or drop the write built-ins from `allowed-tools` and let each
+      write go through the normal approval path. If the command must both be
+      model-invocable and write, scope what it can touch with a PreToolUse hook.
+
+  - id: CCMD-003
+    title: Slash command grants model-driven web retrieval
+    severity: medium
+    confidence: 0.75
+    applies_to:
+      - claude_slash_command
+    scope: slash_command
+    match:
+      slash_command_allows_tool:
+        - WebFetch
+        - WebSearch
+    explanation: >
+      This slash command's `allowed-tools` includes a web-retrieval built-in, so
+      content the model chooses to fetch is pre-approved and flows back into the
+      conversation as text. Retrieved pages and search results are
+      attacker-reachable — anyone can publish a page that ranks for a likely
+      query — which makes the grant a second-order prompt-injection channel, and
+      the request itself a way to carry in-context data out in a URL or query
+      string. The same grant on a subagent is CSDK-112 and CSDK-124.
+    fix: >
+      Remove `WebFetch` / `WebSearch` from `allowed-tools` unless the command's
+      job genuinely needs open web access. If it does, treat everything returned
+      as untrusted input: keep it out of instructions, do not let it widen tool
+      permissions, and prefer fetching a pinned URL the command controls over one
+      the model chooses.

--- a/langchain/agent_safety.yaml
+++ b/langchain/agent_safety.yaml
@@ -9,7 +9,7 @@ policy:
 rules:
   - id: LC-101
     title: LangChain agent wires a code-execution or shell built-in tool
-    severity: high
+    severity: critical
     confidence: 0.85
     language: python
     applies_to:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 22
+schema_version: 23

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 14
+schema_version: 22

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 23
+schema_version: 24

--- a/mcp/installed_package_behavior.yaml
+++ b/mcp/installed_package_behavior.yaml
@@ -1,0 +1,142 @@
+policy:
+  id: mcp_installed_package_behavior
+  name: Installed MCP server behavior
+  category: mcp
+  description: >
+    Behavior observed in the source of an MCP server this repository has actually
+    installed. These rules read dependency source, which the default scan never
+    opens, and they fire only when the reader asks for that pass.
+
+    They are deliberately LOCAL findings, not published advisories. A finding
+    here says "the code in your node_modules does this, at this line"; it makes
+    no claim about the package's author and it leaves the machine. That is the
+    whole reason this surface can ship without the named reviewer, retained
+    evidence and dispute channel a threat-feed entry requires: naming a third
+    party's product in public is a different act from telling an operator what is
+    sitting in their own tree.
+
+    Package rules carry no language: field. An installed package's language is
+    its ecosystem's, and applies_to already discriminates npm from pypi.
+
+rules:
+  - id: MCPKG-001
+    title: Installed MCP server reads a credential and transmits it
+    severity: critical
+    confidence: 0.75
+    applies_to:
+      - npm_package
+      - pypi_package
+    scope: package
+    match:
+      package_behavior_is:
+        - secret_read_plus_egress
+    explanation: >
+      This file reads a credential from the environment and, in the same file,
+      sends a request to a remote host. Neither half is remarkable on its own:
+      reading configuration is ordinary and making an HTTP call is ordinary. The
+      conjunction is the shape worth a person's attention, because it is what
+      exfiltration looks like in source before it looks like anything in a log.
+
+      An MCP server runs with whatever credentials the agent host hands it, and
+      it is trusted to use them for the job it advertises. Code that collects a
+      secret and contacts an address of its own choosing has the means to send
+      that secret somewhere the operator never authorised, whether or not it does
+      so on any particular run. Static reading cannot tell those apart, which is
+      why this is reported rather than blocked.
+
+      The finding is about the copy of the code in this repository. It is not a
+      claim that the package is malicious, and nothing about it is published.
+    fix: >
+      Open the cited file and line and establish where the request goes. If the
+      destination is the service the package exists to talk to, and the credential
+      is that service's own, this is the package doing its job: record it and move
+      on. If the destination is not that service, or the credential belongs to
+      something else, treat it as an incident: rotate the credential, pin or
+      remove the dependency, and preserve the file as evidence before upgrading.
+
+      If you want the behaviour constrained rather than investigated, deny the
+      tool that reaches this server in the agent's contract, which removes the
+      capability regardless of what the package does.
+
+  - id: MCPKG-002
+    title: Installed MCP server adds a fixed extra recipient to outbound messages
+    severity: high
+    confidence: 0.7
+    applies_to:
+      - npm_package
+      - pypi_package
+    scope: package
+    match:
+      package_behavior_is:
+        - silent_recipient_added
+    explanation: >
+      This file sets a bcc-style recipient to an address written into the source,
+      in code that also sends over the network. The address is not a parameter,
+      not configuration and not something the caller chose: it is fixed, so every
+      message this code sends goes to it as well as to the intended recipient.
+
+      An MCP server that composes or forwards messages is trusted with the
+      content of those messages. A copy sent to an address the operator never
+      configured is a durable leak of everything that passes through, and it
+      leaves no trace in the sending application, because from the caller's side
+      the message was delivered exactly as requested.
+
+      A field declaration is not this finding. `bcc?: string` in a type carries no
+      address, and the literal is what separates a feature that lets a user set a
+      bcc from code that sets one on their behalf.
+    fix: >
+      Open the cited line and read the address. If it belongs to the operator's
+      own organisation and was configured deliberately, record that and move on.
+      If it does not, treat every message this server has handled as disclosed:
+      preserve the file as evidence, pin or remove the dependency, and tell
+      whoever owns the affected correspondence before upgrading, because an
+      upgrade destroys the copy that shows what happened.
+
+      Where the behaviour should be under the operator's control rather than the
+      package's, the durable fix is configuration: the recipient list belongs in
+      the server's config where it can be reviewed, not in its source.
+
+  - id: MCPKG-003
+    title: Installed MCP server carries instruction-override text in a string
+    severity: high
+    confidence: 0.6
+    applies_to:
+      - npm_package
+      - pypi_package
+    scope: package
+    match:
+      package_behavior_is:
+        - injection_in_tool_description
+    explanation: >
+      A string in this file instructs the model rather than describing what the
+      code does: text of the "ignore previous instructions" or "do not tell the
+      user" kind. Strings in an MCP server reach the model as tool names,
+      descriptions and results, which is the one place where prose becomes
+      instruction.
+
+      That makes a tool description an injection surface with no equivalent
+      elsewhere. The agent host presents it to the model as trusted metadata about
+      an available capability, so text placed there is read with the authority of
+      the tool list rather than the suspicion given to a document or a web page.
+      "Do not tell the user" in that position is not a comment about behaviour; it
+      is an attempt to configure it.
+
+      Confidence is lower here than for the other package rules, deliberately.
+      The signature requires the string to be the value of a description-like
+      field rather than merely to exist somewhere in the file, which is what
+      keeps a prompt-hardening library's own refusal list out: a library that
+      names an attack is not performing it. What that narrowing gives up is an
+      injection string assigned to a variable and used as a description
+      elsewhere, which is a real evasion and is why this rule reports rather than
+      concludes.
+    fix: >
+      Read the cited line and decide which of the two it is. Text that documents
+      or tests an injection pattern is fine where it sits; text that will be sent
+      to a model as a tool description, a tool result or server instructions is
+      not, and should be removed or rewritten to describe the tool rather than
+      direct the model.
+
+      If the string is reachable by the model and the package is not yours to
+      change, remove the server from the agent's tool list rather than trying to
+      sanitise it downstream: once the text is in the tool description the model
+      has already been told, and filtering the output is too late.

--- a/nvidia_nat/agent_safety.yaml
+++ b/nvidia_nat/agent_safety.yaml
@@ -1,0 +1,90 @@
+policy:
+  id: nvidia_nat_agent_safety
+  name: NeMo Agent Toolkit agent safety
+  category: nvidia_nat
+  description: >
+    Agent-scope rules for NVIDIA NeMo Agent Toolkit workflow configs. A NAT
+    agent is a YAML block (the workflow section, or an agent-typed functions
+    entry), so these rules read the config's own fields: iteration caps that
+    were left to the framework default, and the verbose flag NVIDIA's docs
+    themselves warn logs prompts, outputs and intermediate steps.
+
+rules:
+  - id: NAT-102
+    title: react_agent has no explicit max_tool_calls limit
+    severity: low
+    confidence: 0.6
+    applies_to:
+      - nat_react_agent
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - max_tool_calls
+    explanation: >
+      This react_agent sets no explicit max_tool_calls, so it falls back to
+      the toolkit's default cap (documented as 15). That default prevents a
+      true runaway, but it is a generic ceiling rather than one sized to this
+      agent's role: a model that loops or oscillates still burns up to the
+      full budget of tool round-trips and LLM calls before the agent is
+      forced to answer, a latency and token cost the workflow may not
+      tolerate. The field also accepts the max_iterations alias, and the
+      implicit default can move between toolkit releases without any change
+      in this config.
+    fix: >
+      Set max_tool_calls: in the react_agent block, sized to the role — a
+      single-lookup agent rarely needs more than a handful of calls. Treat
+      hitting the cap as a signal to surface rather than a bound to raise:
+      split genuinely long tasks into bounded sub-workflows instead of
+      removing the ceiling.
+
+  - id: NAT-103
+    title: tool_calling_agent has no explicit max_iterations limit
+    severity: low
+    confidence: 0.6
+    applies_to:
+      - nat_tool_calling_agent
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - max_iterations
+    explanation: >
+      This tool_calling_agent sets no explicit max_iterations, so it falls
+      back to the toolkit's default cap (documented as 15). The default is a
+      generic ceiling rather than one sized to this agent's role, so a model
+      that loops — retrying a failing tool, re-reading the same source —
+      keeps consuming turns, tokens and tool side effects until the implicit
+      bound is reached, and that bound can shift between toolkit releases
+      without any change in this config.
+    fix: >
+      Set max_iterations: in the tool_calling_agent block, sized to the work
+      the agent actually does. Pair a tight cap with handle_tool_errors so a
+      failing tool surfaces as an error result instead of another iteration.
+
+  - id: NAT-104
+    title: Agent runs with verbose logging of prompts and outputs
+    severity: low
+    confidence: 0.8
+    applies_to:
+      - nat_react_agent
+      - nat_tool_calling_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: verbose
+        value: "true"
+    explanation: >
+      This agent sets verbose: true, which the toolkit documents as logging
+      the agent's input, output and intermediate steps — and whose default of
+      false NVIDIA's own field reference explains as "useful to prevent
+      logging of sensitive data". Whatever flows through the agent (user
+      prompts, retrieved documents, tool results, credentials a tool echoes)
+      lands in the process logs, where log aggregation retains it far outside
+      the conversation's trust boundary. Every vendor example config ships
+      with verbose on, so a workflow scaffolded from an example carries this
+      into production unless someone deliberately turns it off.
+    fix: >
+      Remove verbose: true (the default is false) for production configs, or
+      scope it to development profiles only. If step-level observability is
+      the goal, prefer the telemetry section's tracing configuration, which
+      is built for that and can be pointed at a store with appropriate
+      retention, over raw verbose logs.

--- a/nvidia_nat/mcp.yaml
+++ b/nvidia_nat/mcp.yaml
@@ -1,0 +1,118 @@
+policy:
+  id: nvidia_nat_mcp
+  name: NeMo Agent Toolkit MCP and code-execution wiring
+  category: nvidia_nat
+  description: >
+    Rules for the surfaces a NAT config wires in from OUTSIDE the repo: the
+    mcp_client function groups that hand an agent a remote MCP server's tool
+    catalog, and the code_execution function that sends model-written code to
+    an execution service. What these have in common is that the config is the
+    only place a reviewer can bound them.
+
+rules:
+  - id: NAT-101
+    title: Agent wires an mcp_client group with no include or exclude filter
+    severity: high
+    confidence: 0.75
+    applies_to:
+      - nat_react_agent
+      - nat_tool_calling_agent
+    scope: agent
+    match:
+      all:
+        - agent_uses_hosted_tool_class: [mcp_client, per_user_mcp_client]
+        - not:
+            any:
+              - agent_hosted_tool_kwarg_present:
+                  class: mcp_client
+                  kwarg: include
+              - agent_hosted_tool_kwarg_present:
+                  class: mcp_client
+                  kwarg: exclude
+              - agent_hosted_tool_kwarg_present:
+                  class: per_user_mcp_client
+                  kwarg: include
+              - agent_hosted_tool_kwarg_present:
+                  class: per_user_mcp_client
+                  kwarg: exclude
+    explanation: >
+      This agent's tool_names wires an mcp_client function group that sets
+      neither include: nor exclude:. Without a filter, the group registers
+      every tool the remote MCP server currently exposes — a surface that is
+      not enumerable from this config, can grow or change behavior whenever
+      the server is updated, and is entirely outside this repository's
+      control. include/exclude is the toolkit's only mechanism for narrowing
+      that catalog to a reviewed allow-list; without it, the agent inherits
+      the server's full, and potentially server-operator-controlled, tool set
+      with no static boundary a code reviewer can check.
+    fix: >
+      Add include: to the mcp_client group naming the specific tools this
+      agent is allowed to call (include and exclude are mutually exclusive;
+      prefer include, which fails closed as the server grows). Re-review the
+      list whenever the agent's task changes, and treat any server tool not
+      named as excluded by default.
+
+  - id: NAT-105
+    title: mcp_client connects over SSE, a transport with no authentication
+    severity: medium
+    confidence: 0.6
+    applies_to:
+      - nat_react_agent
+      - nat_tool_calling_agent
+    scope: agent
+    match:
+      any:
+        - agent_hosted_tool_kwarg_value:
+            class: mcp_client
+            kwarg: server.transport
+            value: sse
+        - agent_hosted_tool_kwarg_value:
+            class: per_user_mcp_client
+            kwarg: server.transport
+            value: sse
+    explanation: >
+      This agent's mcp_client group connects over the SSE transport, which
+      the toolkit's own documentation flags as supporting no authentication:
+      auth_provider is only honored on streamable-http, so an SSE connection
+      to an MCP server is structurally unauthenticatable from this config.
+      NVIDIA's guidance limits SSE to local development on localhost or
+      behind an authenticating reverse proxy; anywhere else, whoever can
+      reach the endpoint can serve this agent's tools.
+    fix: >
+      Use transport: streamable-http with an auth_provider for anything
+      beyond local development. If SSE must stay (a local dev loop), keep the
+      URL on localhost and treat the config as non-promotable to shared
+      environments as it stands.
+
+  - id: NAT-106
+    title: code_execution function configured with no guardrails middleware
+    severity: medium
+    confidence: 0.6
+    applies_to:
+      - nvidia_nat
+    scope: repo
+    match:
+      all:
+        - repo_component_present: [nat_code_execution_function]
+        - not:
+            any:
+              - repo_component_present: [nat_guardrails_middleware]
+              - repo_component_present: [nat_hitl_middleware]
+    explanation: >
+      A workflow config in this repo declares a code_execution function,
+      which sends a string of model-written Python to an execution service —
+      and no config declares the toolkit's guardrails middleware (or a
+      recognizable human-in-the-loop middleware) to stand between the model
+      and that capability. Model-written code is the widest tool an agent can
+      hold: whatever the execution sandbox permits, a prompt-injected or
+      simply wrong model can do. The toolkit's own mitigation surfaces are
+      the guardrails middleware (a policy engine at function input and output
+      boundaries) and HITL approval middleware; with neither declared, the
+      only bound is the execution service itself.
+    fix: >
+      Add a guardrails middleware entry (type guardrails) and attach it to
+      the workflow via its middleware: list, or gate the function behind a
+      HITL approval middleware. Custom HITL middleware with its own _type is
+      not statically recognizable here — if this repo uses one, the finding
+      is a prompt to make that mitigation visible in review, not to add a
+      second one.

--- a/openai_sdk/agent_safety.yaml
+++ b/openai_sdk/agent_safety.yaml
@@ -222,3 +222,103 @@ rules:
       wire it via `inputGuardrails: [...]` on the `Agent({...})` constructor. Pin
       MCP servers to trusted endpoints and treat web and file results as untrusted
       data.
+  - id: OAI-107
+    title: Handoff-target agent wires shell or filesystem-touching tools
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - openai_agent
+      - openai_sandbox_agent
+    scope: agent
+    match:
+      all:
+        - agent_is_subagent_of_any: true
+        - agent_uses_tool_kind: [shell_invocation]
+    explanation: >
+      This agent is the target of a handoff (it appears in another agent's
+      handoffs=[...]) AND is wired with tools that execute shell commands or
+      touch the filesystem. In the OpenAI Agents SDK, input_guardrails run
+      only on the agent that first receives the user input — a handoff target
+      never runs its own input_guardrails on the handed-off turn. A parent can
+      therefore route around its own guardrails by delegating to this child and
+      asking it to run the shell-touching tool the parent would have screened.
+      The child's privileged tools then execute on input that no guardrail
+      ever inspected. This is why the rule does not require the child's
+      input_guardrails to be empty: even a child that declares guardrails does
+      not run them on the delegated turn, so the shell exposure is the hazard
+      regardless.
+    fix: >
+      Either remove the shell or filesystem-touching tools from this handoff
+      target, or move the privileged tools up to the top-level agent that
+      receives user input — where its input_guardrails actually run — and have
+      that agent do the work instead of delegating it. If the handoff must
+      stay, validate the handoff payload before it reaches the child (for
+      example with an @input_guardrail on the parent and an input_filter on
+      the handoff), since the SDK will not run the child's own guardrails on
+      the delegated turn.
+
+  
+  - id: OAI-114
+    title: Guarded agent transitively wields shell through its handoff chain
+    severity: high
+    confidence: 0.6
+    language: python
+    applies_to:
+      - openai_agent
+      - openai_sandbox_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_present:
+            - input_guardrails
+        - transitive_capability_exceeds_direct:
+            - shell
+    explanation: >
+      This agent declares input_guardrails but delegates — directly or through
+      a chain of handoffs — to an agent whose tools execute shell commands, a
+      capability this agent does not wield itself. In the OpenAI Agents SDK,
+      input_guardrails run only on the agent that first receives the user
+      input, and a handoff target never runs its own input_guardrails on the
+      delegated turn. The guardrails here therefore create false confidence:
+      the shell-executing turn happens downstream, on a payload the handoff
+      may have transformed, with no guardrail in front of it.
+    fix: >
+      Treat the handoff chain as part of this agent's attack surface. Either
+      move the shell-wielding work up to this agent, where its guardrails
+      actually run; remove the shell tools from the downstream agent; or
+      constrain the delegated payload explicitly — an input_filter on the
+      handoff plus tool-level validation on the downstream agent.
+
+  
+  - id: OAI-113
+    title: Unguarded agent's handoff chain reaches shell execution
+    severity: medium
+    confidence: 0.6
+    language: python
+    applies_to:
+      - openai_agent
+      - openai_sandbox_agent
+    scope: agent
+    match:
+      all:
+        - not:
+            agent_kwarg_present:
+              - input_guardrails
+        - transitive_capability_exceeds_direct:
+            - shell
+    explanation: >
+      This agent declares no input_guardrails and delegates, directly or
+      through a chain of handoffs, to an agent whose tools execute shell
+      commands — a capability this agent does not wield itself. If this agent
+      is where user input enters, nothing screens that input anywhere on a
+      delegation path that ends in shell execution: input_guardrails run only
+      on the first agent in the run, and handoff targets never run their own
+      on delegated turns. The chain makes the exposure easy to miss — each
+      agent looks harmless in isolation.
+    fix: >
+      Add input_guardrails to this agent so the entry point of the delegation
+      chain screens input before any downstream shell tool can act on it, and
+      review whether the downstream agent's shell access is needed at all.
+      The downstream agent's own configuration is flagged separately by the
+      direct shell-tool rules.

--- a/openai_sdk/tool_definition.yaml
+++ b/openai_sdk/tool_definition.yaml
@@ -95,3 +95,30 @@ rules:
       Provide a concise `description` string in the `tool({...})` options stating
       what the tool does and when the model should call it. The description is the
       model's primary routing signal alongside the tool name.
+
+  - id: OAI-025
+    title: Tool is defined but never referenced anywhere in the repo
+    severity: low
+    confidence: 0.5
+    language: python
+    applies_to:
+      - openai_tool
+    scope: tool
+    match:
+      reachability_is:
+        - unreachable
+    explanation: >
+      This @function_tool-decorated function is never referenced anywhere in
+      the repo's Python code — it appears in no Agent's tools=[...], no
+      handoff, and no call site. Trustabl's call-graph liveness marks a tool
+      unreachable only when nothing references its name at all, so this is
+      dead capability code: it is not exposed to any model today, but it
+      carries tool-grade capability (and drifts unreviewed) until a later
+      refactor wires it in. Dead tool definitions also misdirect review
+      effort toward code no agent can call.
+    fix: >
+      Delete the tool definition, or wire it into the intended agent's
+      tools=[...] list deliberately. If the tool is dispatched dynamically
+      (getattr, a string-keyed registry), static liveness cannot see that
+      reference — prefer a direct name reference so both the model wiring
+      and this analysis can track it.

--- a/runtime/conformance.yaml
+++ b/runtime/conformance.yaml
@@ -1,0 +1,126 @@
+policy:
+  id: runtime_conformance
+  name: Runtime conformance
+  category: runtime
+  description: >
+    Runtime-scope rules over the signed conformance summary the runtime
+    writes and the guard reads. Evaluated ENGINE-SIDE (the runtime is a
+    separate Go module and cannot import the rule engine), over runtime
+    observations judged against the compiled contract. The one scope whose
+    input is not a scan artifact: it is behavior, bound and judged, joined
+    back to what was declared. These rules DETECT and report; nothing here
+    blocks a call, and no rule text may imply otherwise.
+
+rules:
+  - id: RT-001
+    title: Tool call outside the declared contract
+    severity: high
+    confidence: 0.9
+    applies_to:
+      - conformance_summary
+    scope: runtime
+    match:
+      action_status_is:
+        - off_contract
+    explanation: >
+      A declared agent executed a tool its contract does not grant. This is
+      the runtime fact the whole compile chain exists to catch: the action
+      was bound to the agent with confidence (this is not a binding failure,
+      which is reported separately), judged against the declared allow-list,
+      and refused by it. The finding carries the constraint id the verdict
+      cites, so the violation resolves back to the exact compiled limit and
+      its provenance.
+    fix: >
+      If the behavior is intended, declare the tool on the agent and
+      re-export the contract so the grant is reviewed like any other
+      authority change. If it is not intended, treat this as a live
+      incident signal: the agent is doing something nobody declared.
+
+  - id: RT-002
+    title: Unbound rate above the measured threshold
+    severity: medium
+    confidence: 0.8
+    applies_to:
+      - conformance_summary
+    scope: runtime
+    match:
+      summary_unbound_rate_gte: 10
+    explanation: >
+      More than 10% of the window's observed actions could not be bound to
+      any declared agent (unknown agent, unresolvable tool, or an ambiguous
+      name collision). Above this threshold, per-decision attribution
+      degrades: the off-contract rate is computed over a shrinking base and
+      every conformance claim weakens with it. The threshold is the one the
+      R1 corpus measurement named, not a guess.
+    fix: >
+      Stamp the deployment with the binding key (OTEL_RESOURCE_ATTRIBUTES,
+      printed by contract export and every guard publish) so the contract
+      resolves exactly; name call-based agents where the SDK allows it; and
+      check the unbound breakdown in the summary for which failure mode
+      dominates.
+
+  - id: RT-003
+    title: Runtime carries a contract hash that matches no stored contract
+    severity: high
+    confidence: 0.9
+    applies_to:
+      - conformance_summary
+    scope: runtime
+    match:
+      action_has_hash_miss: true
+    explanation: >
+      A span arrived stamped with a contract hash that resolves to nothing
+      in the content-addressed store: the workload is running under a policy
+      version this site no longer retains, or was stamped by a pipeline this
+      guard has never seen. Binding degraded to name matching (never
+      force-fit), so the verdicts still stand, but the exact-join guarantee
+      is gone for these actions and the deployment's policy lineage cannot
+      be verified.
+    fix: >
+      Re-deploy the workload with the binding key from the current contract
+      export, or raise the guard's contract-history retention
+      (--contract-history-keep) if legitimate older versions are being
+      pruned before their workloads drain.
+
+  - id: RT-004
+    title: Guardrail declared but never observed at runtime
+    severity: low
+    confidence: 0.6
+    applies_to:
+      - conformance_summary
+    scope: runtime
+    match:
+      summary_guards_never_observed: true
+    explanation: >
+      The contract declares input or output guardrails, and the observation
+      window contains no runtime evidence of any executing. Today that
+      absence is expected — no ingest convention extracts guardrail spans
+      yet — which is why this fires at low confidence: it reports the
+      observability gap itself. A declared control that leaves no runtime
+      trace cannot be shown to have run, which is precisely the class of
+      claim an auditor will not accept on declaration alone.
+    fix: >
+      Instrument guardrail execution so it emits spans (the summary's
+      guards_observed field is ready to carry them), or record explicitly
+      that guardrail conformance is asserted from static declaration only.
+
+  - id: RT-005
+    title: Declared constraint never exercised in the window
+    severity: low
+    confidence: 0.6
+    applies_to:
+      - conformance_summary
+    scope: runtime
+    match:
+      summary_constraint_never_hit: true
+    explanation: >
+      At least one compiled constraint was never hit by any observed action
+      across the window: no grant it governs was used and no denial it backs
+      fired. A constraint that is never exercised is not wrong, but it is
+      unverified in practice — the authority it fences either is not being
+      used (possible over-grant) or is not being observed. The summary IS
+      the window; the finding lists how many constraints went unexercised.
+    fix: >
+      Review the unexercised constraints against actual usage: narrow grants
+      nobody uses (the least-privilege win this surfaces), or extend the
+      observation window before concluding anything.


### PR DESCRIPTION
## What this merges

- The `reconcile/fixture-production-parity` branch (the 2026-08-31 fixture/production reconciliation, the NVIDIA NAT pack, the runtime conformance pack and RT-006) with `origin/main` merged in as of 2026-09-11 (`5786bac`).
- Rule count 210 to 235. New packs: `claude_skill/slash_command_safety.yaml` (CCMD-001..003), `mcp/installed_package_behavior.yaml` (MCPKG-001..003), `nvidia_nat/` (NAT-101..106) and `runtime/conformance.yaml` (RT-001..006). Formerly fixture-only rules now ship: CSDK-113, CSDK-207, OAI-025, OAI-107, OAI-113, OAI-114. Severity and confidence were reconciled per file with direction review; the engine's `CLAUDE.md` three-repo section records which side each decision came from.
- `schema_version` 15 to 25.

## Id collision, resolved the shipped-id way

- main shipped CSDK-205 (a Claude Agent SDK session with `acceptEdits` and no `disallowed_tools`, PR #119) while the branch carried a different CSDK-205 from the engine fixture (project settings pre-approve side-effecting tools). Shipped ids never change: main's rule keeps CSDK-205 and the fixture's rule is renumbered CSDK-207. `claude_sdk/repo.yaml` is ordered by id.
- OAI-115, OAI-116 and CSDK-205 from main are kept verbatim. The guard fixture now mirrors them with fire and silent cases, and the guard gains `repo_claude_options_disallowed_tools_missing` at schema 25 so CSDK-205 is evaluated there instead of skipped.

## Verification

- trustabl-guard at schema 25: `trustabl rules validate` reports 90 packs and 235 rules valid; `scripts/check-rules-sync.sh` against this branch reports zero production-only, zero fixture-only and zero drift; `go test ./...` is green.
- trustabl-rulebook: `tools/check_rulebook.py --rules-repo <this branch>` passes with 0 errors after adding the rationale docs for CSDK-205, CSDK-207, OAI-115 and OAI-116.

## Known consequence before merging

- The `validate` workflow builds `trustabl/agent-reliability-analyzer`, which is at schema 15 and validates strictly. It rejects this branch (unknown predicates in eight packs, unknown categories `nvidia_nat` and `runtime`), so this PR's check is red and stays red on main until the open scanner learns the schema 16..25 predicates or the workflow tolerates forward-compatible packs.
- Scans are not affected. The analyzer's scan path loads leniently (`LoadLenient` in `rule_detector.go`), skips the rules it cannot decode and warns on stderr; the guard loads all 235.
- Every consumer that fetches main at scan time sees a new rules SHA and changed findings: the critical reclasses (CSDK-103, CSDK-120, CSDK-201, CSDK-202, LC-101) and the new rules. The NVIDIA PoC build is one of those consumers.
